### PR TITLE
feat: WalletConnect integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# for running e2e tests
+WALLETCONNECT_PROJECT_ID=

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 coverage
+.env

--- a/index.js
+++ b/index.js
@@ -17,6 +17,7 @@
 /** @typedef {import('./src/wdk-manager.js').IWalletAccount} IWalletAccount */
 /** @typedef {import('./src/wdk-manager.js').FeeRates} FeeRates */
 /** @typedef {import('./src/wdk-manager.js').MiddlewareFunction} MiddlewareFunction */
+/** @typedef {import('./src/wdk-manager.js').WalletConnectConfig} WalletConnectConfig */
 
 /** @typedef {import('./src/wallet-account-with-protocols.js').IWalletAccountWithProtocols} IWalletAccountWithProtocols */
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,13 +9,11 @@
       "version": "1.0.0-beta.7",
       "license": "Apache-2.0",
       "dependencies": {
-        "@json-rpc-tools/utils": "^1.7.6",
         "@reown/walletkit": "^1.5.5",
         "@tetherto/wdk-wallet": "^1.0.0-beta.6",
         "@walletconnect/pay": "^1.0.8",
         "@walletconnect/utils": "^2.23.9",
-        "bare-node-runtime": "^1.1.4",
-        "tslib": "^2.8.1"
+        "bare-node-runtime": "^1.1.4"
       },
       "devDependencies": {
         "@walletconnect/sign-client": "^2.23.9",
@@ -1168,27 +1166,6 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
-    "node_modules/@json-rpc-tools/types": {
-      "version": "1.7.6",
-      "resolved": "https://registry.npmjs.org/@json-rpc-tools/types/-/types-1.7.6.tgz",
-      "integrity": "sha512-nDSqmyRNEqEK9TZHtM15uNnDljczhCUdBmRhpNZ95bIPKEDQ+nTDmGMFd2lLin3upc5h2VVVd9tkTDdbXUhDIQ==",
-      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
-      "license": "MIT",
-      "dependencies": {
-        "keyvaluestorage-interface": "^1.0.0"
-      }
-    },
-    "node_modules/@json-rpc-tools/utils": {
-      "version": "1.7.6",
-      "resolved": "https://registry.npmjs.org/@json-rpc-tools/utils/-/utils-1.7.6.tgz",
-      "integrity": "sha512-HjA8x/U/Q78HRRe19yh8HVKoZ+Iaoo3YZjakJYxR+rw52NHo6jM+VE9b8+7ygkCFXl/EHID5wh/MkXaE/jGyYw==",
-      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
-      "license": "MIT",
-      "dependencies": {
-        "@json-rpc-tools/types": "^1.7.6",
-        "@pedrouid/environment": "^1.0.1"
-      }
-    },
     "node_modules/@msgpack/msgpack": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/@msgpack/msgpack/-/msgpack-3.1.3.tgz",
@@ -1299,12 +1276,6 @@
       "engines": {
         "node": ">= 8"
       }
-    },
-    "node_modules/@pedrouid/environment": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@pedrouid/environment/-/environment-1.0.1.tgz",
-      "integrity": "sha512-HaW78NszGzRZd9SeoI3JD11JqY+lubnaOx7Pewj5pfjqWXOEATpeKIFb9Z4t2WBUK2iryiXX3lzWwmYWgUL0Ug==",
-      "license": "MIT"
     },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
@@ -9376,7 +9347,9 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD"
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,15 +9,28 @@
       "version": "1.0.0-beta.7",
       "license": "Apache-2.0",
       "dependencies": {
+        "@json-rpc-tools/utils": "^1.7.6",
+        "@reown/walletkit": "^1.5.5",
         "@tetherto/wdk-wallet": "^1.0.0-beta.6",
-        "bare-node-runtime": "^1.1.4"
+        "@walletconnect/pay": "^1.0.8",
+        "@walletconnect/utils": "^2.23.9",
+        "bare-node-runtime": "^1.1.4",
+        "tslib": "^2.8.1"
       },
       "devDependencies": {
+        "@walletconnect/sign-client": "^2.23.9",
         "cross-env": "7.0.3",
+        "dotenv": "^17.4.2",
         "jest": "30.1.3",
         "standard": "17.1.2",
         "typescript": "5.8.3"
       }
+    },
+    "node_modules/@adraffy/ens-normalize": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.11.1.tgz",
+      "integrity": "sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ==",
+      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.27.1",
@@ -1155,6 +1168,36 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@json-rpc-tools/types": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@json-rpc-tools/types/-/types-1.7.6.tgz",
+      "integrity": "sha512-nDSqmyRNEqEK9TZHtM15uNnDljczhCUdBmRhpNZ95bIPKEDQ+nTDmGMFd2lLin3upc5h2VVVd9tkTDdbXUhDIQ==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "license": "MIT",
+      "dependencies": {
+        "keyvaluestorage-interface": "^1.0.0"
+      }
+    },
+    "node_modules/@json-rpc-tools/utils": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@json-rpc-tools/utils/-/utils-1.7.6.tgz",
+      "integrity": "sha512-HjA8x/U/Q78HRRe19yh8HVKoZ+Iaoo3YZjakJYxR+rw52NHo6jM+VE9b8+7ygkCFXl/EHID5wh/MkXaE/jGyYw==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "license": "MIT",
+      "dependencies": {
+        "@json-rpc-tools/types": "^1.7.6",
+        "@pedrouid/environment": "^1.0.1"
+      }
+    },
+    "node_modules/@msgpack/msgpack": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@msgpack/msgpack/-/msgpack-3.1.3.tgz",
+      "integrity": "sha512-47XIizs9XZXvuJgoaJUIE2lFoID8ugvc0jzSHP+Ptfk8nTbnR8g788wv48N03Kx0UkAv559HWRQ3yzOgzlRNUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "0.2.12",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
@@ -1166,6 +1209,45 @@
         "@emnapi/core": "^1.4.3",
         "@emnapi/runtime": "^1.4.3",
         "@tybys/wasm-util": "^0.10.0"
+      }
+    },
+    "node_modules/@noble/ciphers": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
+      "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/curves": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.8.0.tgz",
+      "integrity": "sha512-j84kjAbzEnQHaSIhRPUmB3/eVXu2k3dKPl2LOrR8fSOIL+89U+7lV117EWHtq/GHM3ReGHM46iRBdZfpc4HRUQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.7.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/curves/node_modules/@noble/hashes": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.7.0.tgz",
+      "integrity": "sha512-HXydb0DgzTpDPwbVeDGCG1gIu7X6+AuU6Zl6av/E/KG8LMsvPntvq+w17CHRpKBmN6Ybdrt1eP3k4cj8DJa78w==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@noble/hashes": {
@@ -1218,6 +1300,12 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@pedrouid/environment": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@pedrouid/environment/-/environment-1.0.1.tgz",
+      "integrity": "sha512-HaW78NszGzRZd9SeoI3JD11JqY+lubnaOx7Pewj5pfjqWXOEATpeKIFb9Z4t2WBUK2iryiXX3lzWwmYWgUL0Ug==",
+      "license": "MIT"
+    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -1242,12 +1330,79 @@
         "url": "https://opencollective.com/pkgr"
       }
     },
+    "node_modules/@reown/walletkit": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@reown/walletkit/-/walletkit-1.5.5.tgz",
+      "integrity": "sha512-Od8XpSCuGIkckTF5Qy7qUm0vcay98D0Vqz94wEUDz581nSipWfJIsKbm0dL2Da/wme/KcyIipLtfJN5w/GtnRw==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@walletconnect/core": "2.23.9",
+        "@walletconnect/jsonrpc-provider": "1.0.14",
+        "@walletconnect/jsonrpc-utils": "1.0.8",
+        "@walletconnect/logger": "3.0.2",
+        "@walletconnect/pay": "1.0.8",
+        "@walletconnect/sign-client": "2.23.9",
+        "@walletconnect/types": "2.23.9",
+        "@walletconnect/utils": "2.23.9"
+      }
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
       "integrity": "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@scure/base": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.2.6.tgz",
+      "integrity": "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip32": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.7.0.tgz",
+      "integrity": "sha512-E4FFX/N3f4B80AKWp5dP6ow+flD1LQZo/w8UnLGYZO674jS6YnYeepycOOksv+vLPSpgN35wgKgy+ybfTb2SMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "~1.9.0",
+        "@noble/hashes": "~1.8.0",
+        "@scure/base": "~1.2.5"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip32/node_modules/@noble/curves": {
+      "version": "1.9.7",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.7.tgz",
+      "integrity": "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip39": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.6.0.tgz",
+      "integrity": "sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "~1.8.0",
+        "@scure/base": "~1.2.5"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.34.41",
@@ -1686,6 +1841,364 @@
         "win32"
       ]
     },
+    "node_modules/@walletconnect/core": {
+      "version": "2.23.9",
+      "resolved": "https://registry.npmjs.org/@walletconnect/core/-/core-2.23.9.tgz",
+      "integrity": "sha512-ws4WG8LeagUo2ERRo02HryXRcpwIRmCQ3pHLW5gWbVReLXXIpgk6ZAfID3fEGHevIwwnHSGww+nNhNpdXyiq0g==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@walletconnect/heartbeat": "1.2.2",
+        "@walletconnect/jsonrpc-provider": "1.0.14",
+        "@walletconnect/jsonrpc-types": "1.0.4",
+        "@walletconnect/jsonrpc-utils": "1.0.8",
+        "@walletconnect/jsonrpc-ws-connection": "1.0.16",
+        "@walletconnect/keyvaluestorage": "1.1.1",
+        "@walletconnect/logger": "3.0.2",
+        "@walletconnect/relay-api": "1.0.11",
+        "@walletconnect/relay-auth": "1.1.0",
+        "@walletconnect/safe-json": "1.0.2",
+        "@walletconnect/time": "1.0.2",
+        "@walletconnect/types": "2.23.9",
+        "@walletconnect/utils": "2.23.9",
+        "@walletconnect/window-getters": "1.0.1",
+        "es-toolkit": "1.44.0",
+        "events": "3.3.0",
+        "uint8arrays": "3.1.1"
+      },
+      "engines": {
+        "node": ">=18.20.8"
+      }
+    },
+    "node_modules/@walletconnect/environment": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@walletconnect/environment/-/environment-1.0.1.tgz",
+      "integrity": "sha512-T426LLZtHj8e8rYnKfzsw1aG6+M0BT1ZxayMdv/p8yM0MU+eJDISqNY3/bccxRr4LrF9csq02Rhqt08Ibl0VRg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "1.14.1"
+      }
+    },
+    "node_modules/@walletconnect/environment/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "license": "0BSD"
+    },
+    "node_modules/@walletconnect/events": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@walletconnect/events/-/events-1.0.1.tgz",
+      "integrity": "sha512-NPTqaoi0oPBVNuLv7qPaJazmGHs5JGyO8eEAk5VGKmJzDR7AHzD4k6ilox5kxk1iwiOnFopBOOMLs86Oa76HpQ==",
+      "license": "MIT",
+      "dependencies": {
+        "keyvaluestorage-interface": "^1.0.0",
+        "tslib": "1.14.1"
+      }
+    },
+    "node_modules/@walletconnect/events/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "license": "0BSD"
+    },
+    "node_modules/@walletconnect/heartbeat": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@walletconnect/heartbeat/-/heartbeat-1.2.2.tgz",
+      "integrity": "sha512-uASiRmC5MwhuRuf05vq4AT48Pq8RMi876zV8rr8cV969uTOzWdB/k+Lj5yI2PBtB1bGQisGen7MM1GcZlQTBXw==",
+      "license": "MIT",
+      "dependencies": {
+        "@walletconnect/events": "^1.0.1",
+        "@walletconnect/time": "^1.0.2",
+        "events": "^3.3.0"
+      }
+    },
+    "node_modules/@walletconnect/jsonrpc-provider": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-provider/-/jsonrpc-provider-1.0.14.tgz",
+      "integrity": "sha512-rtsNY1XqHvWj0EtITNeuf8PHMvlCLiS3EjQL+WOkxEOA4KPxsohFnBDeyPYiNm4ZvkQdLnece36opYidmtbmow==",
+      "license": "MIT",
+      "dependencies": {
+        "@walletconnect/jsonrpc-utils": "^1.0.8",
+        "@walletconnect/safe-json": "^1.0.2",
+        "events": "^3.3.0"
+      }
+    },
+    "node_modules/@walletconnect/jsonrpc-types": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-types/-/jsonrpc-types-1.0.4.tgz",
+      "integrity": "sha512-P6679fG/M+wuWg9TY8mh6xFSdYnFyFjwFelxyISxMDrlbXokorEVXYOxiqEbrU3x1BmBoCAJJ+vtEaEoMlpCBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "events": "^3.3.0",
+        "keyvaluestorage-interface": "^1.0.0"
+      }
+    },
+    "node_modules/@walletconnect/jsonrpc-utils": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-utils/-/jsonrpc-utils-1.0.8.tgz",
+      "integrity": "sha512-vdeb03bD8VzJUL6ZtzRYsFMq1eZQcM3EAzT0a3st59dyLfJ0wq+tKMpmGH7HlB7waD858UWgfIcudbPFsbzVdw==",
+      "license": "MIT",
+      "dependencies": {
+        "@walletconnect/environment": "^1.0.1",
+        "@walletconnect/jsonrpc-types": "^1.0.3",
+        "tslib": "1.14.1"
+      }
+    },
+    "node_modules/@walletconnect/jsonrpc-utils/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "license": "0BSD"
+    },
+    "node_modules/@walletconnect/jsonrpc-ws-connection": {
+      "version": "1.0.16",
+      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-ws-connection/-/jsonrpc-ws-connection-1.0.16.tgz",
+      "integrity": "sha512-G81JmsMqh5nJheE1mPst1W0WfVv0SG3N7JggwLLGnI7iuDZJq8cRJvQwLGKHn5H1WTW7DEPCo00zz5w62AbL3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@walletconnect/jsonrpc-utils": "^1.0.6",
+        "@walletconnect/safe-json": "^1.0.2",
+        "events": "^3.3.0",
+        "ws": "^7.5.1"
+      }
+    },
+    "node_modules/@walletconnect/keyvaluestorage": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@walletconnect/keyvaluestorage/-/keyvaluestorage-1.1.1.tgz",
+      "integrity": "sha512-V7ZQq2+mSxAq7MrRqDxanTzu2RcElfK1PfNYiaVnJgJ7Q7G7hTVwF8voIBx92qsRyGHZihrwNPHuZd1aKkd0rA==",
+      "license": "MIT",
+      "dependencies": {
+        "@walletconnect/safe-json": "^1.0.1",
+        "idb-keyval": "^6.2.1",
+        "unstorage": "^1.9.0"
+      },
+      "peerDependencies": {
+        "@react-native-async-storage/async-storage": "1.x"
+      },
+      "peerDependenciesMeta": {
+        "@react-native-async-storage/async-storage": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@walletconnect/logger": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@walletconnect/logger/-/logger-3.0.2.tgz",
+      "integrity": "sha512-7wR3wAwJTOmX4gbcUZcFMov8fjftY05+5cO/d4cpDD8wDzJ+cIlKdYOXaXfxHLSYeDazMXIsxMYjHYVDfkx+nA==",
+      "license": "MIT",
+      "dependencies": {
+        "@walletconnect/safe-json": "^1.0.2",
+        "pino": "10.0.0"
+      }
+    },
+    "node_modules/@walletconnect/pay": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@walletconnect/pay/-/pay-1.0.8.tgz",
+      "integrity": "sha512-0LaCIlt0XIST8CpwuUHH9z485PEX+1J869tAq04zgPIxMA6gNZJ0j7vff2smFNCeKmKjFU4RpOdbw4zDAHcJwg==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@walletconnect/logger": "3.0.2",
+        "@walletconnect/types": "2.23.9",
+        "@walletconnect/utils": "2.23.9",
+        "brotli": "^1.3.3"
+      },
+      "peerDependencies": {
+        "react-native": ">=0.64.0"
+      },
+      "peerDependenciesMeta": {
+        "react-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@walletconnect/relay-api": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@walletconnect/relay-api/-/relay-api-1.0.11.tgz",
+      "integrity": "sha512-tLPErkze/HmC9aCmdZOhtVmYZq1wKfWTJtygQHoWtgg722Jd4homo54Cs4ak2RUFUZIGO2RsOpIcWipaua5D5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@walletconnect/jsonrpc-types": "^1.0.2"
+      }
+    },
+    "node_modules/@walletconnect/relay-auth": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/relay-auth/-/relay-auth-1.1.0.tgz",
+      "integrity": "sha512-qFw+a9uRz26jRCDgL7Q5TA9qYIgcNY8jpJzI1zAWNZ8i7mQjaijRnWFKsCHAU9CyGjvt6RKrRXyFtFOpWTVmCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "1.8.0",
+        "@noble/hashes": "1.7.0",
+        "@walletconnect/safe-json": "^1.0.1",
+        "@walletconnect/time": "^1.0.2",
+        "uint8arrays": "^3.0.0"
+      }
+    },
+    "node_modules/@walletconnect/relay-auth/node_modules/@noble/hashes": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.7.0.tgz",
+      "integrity": "sha512-HXydb0DgzTpDPwbVeDGCG1gIu7X6+AuU6Zl6av/E/KG8LMsvPntvq+w17CHRpKBmN6Ybdrt1eP3k4cj8DJa78w==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@walletconnect/safe-json": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@walletconnect/safe-json/-/safe-json-1.0.2.tgz",
+      "integrity": "sha512-Ogb7I27kZ3LPC3ibn8ldyUr5544t3/STow9+lzz7Sfo808YD7SBWk7SAsdBFlYgP2zDRy2hS3sKRcuSRM0OTmA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "1.14.1"
+      }
+    },
+    "node_modules/@walletconnect/safe-json/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "license": "0BSD"
+    },
+    "node_modules/@walletconnect/sign-client": {
+      "version": "2.23.9",
+      "resolved": "https://registry.npmjs.org/@walletconnect/sign-client/-/sign-client-2.23.9.tgz",
+      "integrity": "sha512-Xj+hw4E6mGRyhCdVOT/RMgnG+up/Y3v0ho5PlkVozvXWeVSqHNh9DmjLuU97a7OACoGd/oHBF6g3NVqD7MgCMQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@walletconnect/core": "2.23.9",
+        "@walletconnect/events": "1.0.1",
+        "@walletconnect/heartbeat": "1.2.2",
+        "@walletconnect/jsonrpc-utils": "1.0.8",
+        "@walletconnect/logger": "3.0.2",
+        "@walletconnect/time": "1.0.2",
+        "@walletconnect/types": "2.23.9",
+        "@walletconnect/utils": "2.23.9",
+        "events": "3.3.0"
+      }
+    },
+    "node_modules/@walletconnect/time": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@walletconnect/time/-/time-1.0.2.tgz",
+      "integrity": "sha512-uzdd9woDcJ1AaBZRhqy5rNC9laqWGErfc4dxA9a87mPdKOgWMD85mcFo9dIYIts/Jwocfwn07EC6EzclKubk/g==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "1.14.1"
+      }
+    },
+    "node_modules/@walletconnect/time/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "license": "0BSD"
+    },
+    "node_modules/@walletconnect/types": {
+      "version": "2.23.9",
+      "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-2.23.9.tgz",
+      "integrity": "sha512-IUl1PpD/Dig8IE2OZ9XtjbPohEyOZJ73xs92EDUzoIyzRtfm36g2D340pY3iu3AAdLv1yFiaZafB8Hf8RFze8A==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@walletconnect/events": "1.0.1",
+        "@walletconnect/heartbeat": "1.2.2",
+        "@walletconnect/jsonrpc-types": "1.0.4",
+        "@walletconnect/keyvaluestorage": "1.1.1",
+        "@walletconnect/logger": "3.0.2",
+        "events": "3.3.0"
+      }
+    },
+    "node_modules/@walletconnect/utils": {
+      "version": "2.23.9",
+      "resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-2.23.9.tgz",
+      "integrity": "sha512-C5TltCs8UPypNiteYnKSv8+ZDK2EjVDyXCxN6kA9bkA+j6KGsNIV7l9MUA8WBAvE5Gi5EcBdhD3R9Hpo/1HHqQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@msgpack/msgpack": "3.1.3",
+        "@noble/ciphers": "1.3.0",
+        "@noble/curves": "1.9.7",
+        "@noble/hashes": "1.8.0",
+        "@scure/base": "1.2.6",
+        "@walletconnect/jsonrpc-utils": "1.0.8",
+        "@walletconnect/keyvaluestorage": "1.1.1",
+        "@walletconnect/logger": "3.0.2",
+        "@walletconnect/relay-api": "1.0.11",
+        "@walletconnect/relay-auth": "1.1.0",
+        "@walletconnect/safe-json": "1.0.2",
+        "@walletconnect/time": "1.0.2",
+        "@walletconnect/types": "2.23.9",
+        "@walletconnect/window-getters": "1.0.1",
+        "@walletconnect/window-metadata": "1.0.1",
+        "blakejs": "1.2.1",
+        "detect-browser": "5.3.0",
+        "ox": "0.9.3",
+        "uint8arrays": "3.1.1"
+      }
+    },
+    "node_modules/@walletconnect/utils/node_modules/@noble/curves": {
+      "version": "1.9.7",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.7.tgz",
+      "integrity": "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@walletconnect/window-getters": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@walletconnect/window-getters/-/window-getters-1.0.1.tgz",
+      "integrity": "sha512-vHp+HqzGxORPAN8gY03qnbTMnhqIwjeRJNOMOAzePRg4xVEEE2WvYsI9G2NMjOknA8hnuYbU3/hwLcKbjhc8+Q==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "1.14.1"
+      }
+    },
+    "node_modules/@walletconnect/window-getters/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "license": "0BSD"
+    },
+    "node_modules/@walletconnect/window-metadata": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@walletconnect/window-metadata/-/window-metadata-1.0.1.tgz",
+      "integrity": "sha512-9koTqyGrM2cqFRW517BPY/iEtUDx2r1+Pwwu5m7sJ7ka79wi3EyqhqcICk/yDmv6jAS1rjKgTKXlEhanYjijcA==",
+      "license": "MIT",
+      "dependencies": {
+        "@walletconnect/window-getters": "^1.0.1",
+        "tslib": "1.14.1"
+      }
+    },
+    "node_modules/@walletconnect/window-metadata/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "license": "0BSD"
+    },
+    "node_modules/abitype": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/abitype/-/abitype-1.2.3.tgz",
+      "integrity": "sha512-Ofer5QUnuUdTFsBRwARMoWKOH1ND5ehwYhJ3OJ/BQO+StkwQjHw0XyVh4vDttzHB7QOFhPHa/o413PJ82gU/Tg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/wevm"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.4",
+        "zod": "^3.22.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/acorn": {
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
@@ -1775,7 +2288,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
       "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "normalize-path": "^3.0.0",
@@ -1963,6 +2475,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/atomic-sleep": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
+      "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/available-typed-arrays": {
@@ -2968,6 +3489,26 @@
         "bare-stream": "^2.0.0"
       }
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.9.8",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.8.tgz",
@@ -2986,6 +3527,12 @@
       "dependencies": {
         "@noble/hashes": "^1.2.0"
       }
+    },
+    "node_modules/blakejs": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/blakejs/-/blakejs-1.2.1.tgz",
+      "integrity": "sha512-QXUSXI3QVc/gJME0dBpXrag1kbzOqCjCX8/b54ntNyW6sjtoqxqRk3LTmXzaJoh71zMsDCjM+47jS7XiwN/+fQ==",
+      "license": "MIT"
     },
     "node_modules/brace-expansion": {
       "version": "2.0.3",
@@ -3008,6 +3555,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/brotli": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/brotli/-/brotli-1.3.3.tgz",
+      "integrity": "sha512-oTKjJdShmDuGW94SyyaoQvAjf30dZaHnjJ8uAF+u2/vGJkJbJPJAT1gDiOJP5v1Zb6f9KEyW/1HpuaWIXtGHPg==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.1.2"
       }
     },
     "node_modules/browserslist": {
@@ -3202,6 +3758,21 @@
         "node": ">=10"
       }
     },
+    "node_modules/chokidar": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
+      "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^5.0.0"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/ci-info": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.3.1.tgz",
@@ -3364,6 +3935,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cookie-es": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-1.2.3.tgz",
+      "integrity": "sha512-lXVyvUvrNXblMqzIRrxHb57UUVmqsSWlxqt3XIjCkUP0wDAf6uicO6KMbEgYrMNtEvWgWHwe42CKxPu9MYAnWw==",
+      "license": "MIT"
+    },
     "node_modules/cross-env": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
@@ -3396,6 +3973,15 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/crossws": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/crossws/-/crossws-0.3.5.tgz",
+      "integrity": "sha512-ojKiDvcmByhwa8YYqbQI/hg7MEU0NC03+pSdEq4ZUnZR9xXpwk7E43SMNGkn+JxJGPFtNvQ48+vV2p+P1ml5PA==",
+      "license": "MIT",
+      "dependencies": {
+        "uncrypto": "^0.1.3"
       }
     },
     "node_modules/data-view-buffer": {
@@ -3538,6 +4124,24 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/defu": {
+      "version": "6.1.7",
+      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.7.tgz",
+      "integrity": "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==",
+      "license": "MIT"
+    },
+    "node_modules/destr": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/destr/-/destr-2.0.5.tgz",
+      "integrity": "sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==",
+      "license": "MIT"
+    },
+    "node_modules/detect-browser": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/detect-browser/-/detect-browser-5.3.0.tgz",
+      "integrity": "sha512-53rsFbGdwMwlF7qvCt0ypLM5V5/Mbl0szB7GPN8y9NCcbknYOeVVXdrXEq+90IwAfrrzt6Hd+u2E2ntakICU8w==",
+      "license": "MIT"
+    },
     "node_modules/detect-newline": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
@@ -3559,6 +4163,19 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dunder-proto": {
@@ -3796,6 +4413,16 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.44.0",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.44.0.tgz",
+      "integrity": "sha512-6penXeZalaV88MM3cGkFZZfOoLGWshWWfdy0tWw/RlVVyhvMaWSBTOvXNeiW3e5FwdS5ePW0LGEu17zT139ktg==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
     },
     "node_modules/escalade": {
       "version": "3.2.0",
@@ -4539,6 +5166,21 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "license": "MIT"
+    },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
     "node_modules/events-universal": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
@@ -5042,6 +5684,23 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/h3": {
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/h3/-/h3-1.15.11.tgz",
+      "integrity": "sha512-L3THSe2MPeBwgIZVSH5zLdBBU90TOxarvhK9d04IDY2AmVS8j2Jz2LIWtwsGOU3lu2I5jCN7FNvVfY2+XyF+mg==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie-es": "^1.2.3",
+        "crossws": "^0.3.5",
+        "defu": "^6.1.6",
+        "destr": "^2.0.5",
+        "iron-webcrypto": "^1.2.1",
+        "node-mock-http": "^1.0.4",
+        "radix3": "^1.1.2",
+        "ufo": "^1.6.3",
+        "uncrypto": "^0.1.3"
+      }
+    },
     "node_modules/has-bigints": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
@@ -5153,6 +5812,12 @@
         "node": ">=10.17.0"
       }
     },
+    "node_modules/idb-keyval": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/idb-keyval/-/idb-keyval-6.2.2.tgz",
+      "integrity": "sha512-yjD9nARJ/jb1g+CvD0tlhUHOrJ9Sy0P8T9MF3YaLlHnSRpwPfpTX0XIvpmw3gAJUmEu3FiICLBDPXVwyEvrleg==",
+      "license": "Apache-2.0"
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -5252,6 +5917,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/iron-webcrypto": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/iron-webcrypto/-/iron-webcrypto-1.2.1.tgz",
+      "integrity": "sha512-feOM6FaSr6rEABp/eDfVseKyTMDt+KGpeB35SkVn9Tyn0CqvVsY3EwI0v5i8nMHyJnzCIQf7nsy3p41TPkJZhg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/brc-dd"
       }
     },
     "node_modules/is-array-buffer": {
@@ -6542,6 +7216,12 @@
         "json-buffer": "3.0.1"
       }
     },
+    "node_modules/keyvaluestorage-interface": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/keyvaluestorage-interface/-/keyvaluestorage-interface-1.0.0.tgz",
+      "integrity": "sha512-8t6Q3TclQ4uZynJY9IGr2+SsIGwK9JHcO6ootkHCGA0CrQCRy+VkouYNO2xicET6b9al7QKzpebNow+gkpCL8g==",
+      "license": "MIT"
+    },
     "node_modules/leven": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
@@ -6790,6 +7470,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/multiformats": {
+      "version": "9.9.0",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
+      "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg==",
+      "license": "(Apache-2.0 AND MIT)"
+    },
     "node_modules/napi-postinstall": {
       "version": "0.3.4",
       "resolved": "https://registry.npmjs.org/napi-postinstall/-/napi-postinstall-0.3.4.tgz",
@@ -6813,11 +7499,23 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/node-fetch-native": {
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.6.7.tgz",
+      "integrity": "sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==",
+      "license": "MIT"
+    },
     "node_modules/node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
       "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/node-mock-http": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/node-mock-http/-/node-mock-http-1.0.4.tgz",
+      "integrity": "sha512-8DY+kFsDkNXy1sJglUfuODx1/opAGJGyrTuFqEoN90oRc2Vk0ZbD4K2qmKXBBEhZQzdKHIVfEJpDU8Ak2NJEvQ==",
       "license": "MIT"
     },
     "node_modules/node-releases": {
@@ -6831,7 +7529,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -6973,6 +7670,26 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/ofetch": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/ofetch/-/ofetch-1.5.1.tgz",
+      "integrity": "sha512-2W4oUZlVaqAPAil6FUg/difl6YhqhUR7x2eZY4bQCko22UXg3hptq9KLQdqFClV+Wu85UX7hNtdGTngi/1BxcA==",
+      "license": "MIT",
+      "dependencies": {
+        "destr": "^2.0.5",
+        "node-fetch-native": "^1.6.7",
+        "ufo": "^1.6.1"
+      }
+    },
+    "node_modules/on-exit-leak-free": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
+      "integrity": "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -7033,6 +7750,51 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/ox": {
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/ox/-/ox-0.9.3.tgz",
+      "integrity": "sha512-KzyJP+fPV4uhuuqrTZyok4DC7vFzi7HLUFiUNEmpbyh59htKWkOC98IONC1zgXJPbHAhQgqs6B0Z6StCGhmQvg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@adraffy/ens-normalize": "^1.11.0",
+        "@noble/ciphers": "^1.3.0",
+        "@noble/curves": "1.9.1",
+        "@noble/hashes": "^1.8.0",
+        "@scure/bip32": "^1.7.0",
+        "@scure/bip39": "^1.6.0",
+        "abitype": "^1.0.9",
+        "eventemitter3": "5.0.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ox/node_modules/@noble/curves": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.1.tgz",
+      "integrity": "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/p-limit": {
@@ -7201,7 +7963,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
       "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -7219,6 +7980,43 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/pino": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-10.0.0.tgz",
+      "integrity": "sha512-eI9pKwWEix40kfvSzqEP6ldqOoBIN7dwD/o91TY5z8vQI12sAffpR/pOqAD1IVVwIVHDpHjkq0joBPdJD0rafA==",
+      "license": "MIT",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^2.0.0",
+        "pino-std-serializers": "^7.0.0",
+        "process-warning": "^5.0.0",
+        "quick-format-unescaped": "^4.0.3",
+        "real-require": "^0.2.0",
+        "safe-stable-stringify": "^2.3.1",
+        "slow-redact": "^0.3.0",
+        "sonic-boom": "^4.0.1",
+        "thread-stream": "^3.0.0"
+      },
+      "bin": {
+        "pino": "bin.js"
+      }
+    },
+    "node_modules/pino-abstract-transport": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-2.0.0.tgz",
+      "integrity": "sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.0.0"
+      }
+    },
+    "node_modules/pino-std-serializers": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.1.0.tgz",
+      "integrity": "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==",
+      "license": "MIT"
     },
     "node_modules/pirates": {
       "version": "4.0.7",
@@ -7371,6 +8169,22 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/process-warning": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.0.0.tgz",
+      "integrity": "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/prop-types": {
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
@@ -7437,12 +8251,46 @@
       ],
       "license": "MIT"
     },
+    "node_modules/quick-format-unescaped": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
+      "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
+      "license": "MIT"
+    },
+    "node_modules/radix3": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/radix3/-/radix3-1.1.2.tgz",
+      "integrity": "sha512-b484I/7b8rDEdSDKckSSBA8knMpcdsXudlE/LNL639wFoHKwLbEkQFZHWEYwDC0wa0FKUcCY+GAF73Z7wxNVFA==",
+      "license": "MIT"
+    },
     "node_modules/react-is": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/readdirp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
+      "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/real-require": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
+      "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12.13.0"
+      }
     },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
@@ -7720,6 +8568,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/safe-stable-stringify": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
+      "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/semver": {
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
@@ -7901,6 +8758,21 @@
         "node": ">=8"
       }
     },
+    "node_modules/slow-redact": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/slow-redact/-/slow-redact-0.3.2.tgz",
+      "integrity": "sha512-MseHyi2+E/hBRqdOi5COy6wZ7j7DxXRz9NkseavNYSvvWC06D8a5cidVZX3tcG5eCW3NIyVU4zT63hw0Q486jw==",
+      "license": "MIT"
+    },
+    "node_modules/sonic-boom": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.1.tgz",
+      "integrity": "sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==",
+      "license": "MIT",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0"
+      }
+    },
     "node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -7920,6 +8792,15 @@
       "dependencies": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
       }
     },
     "node_modules/sprintf-js": {
@@ -8426,6 +9307,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/thread-stream": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-3.1.0.tgz",
+      "integrity": "sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==",
+      "license": "MIT",
+      "dependencies": {
+        "real-require": "^0.2.0"
+      }
+    },
     "node_modules/tmpl": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
@@ -8486,9 +9376,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
-      "license": "0BSD",
-      "optional": true
+      "license": "0BSD"
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -8608,7 +9496,7 @@
       "version": "5.8.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -8633,6 +9521,21 @@
         "bare": ">=1.17.4"
       }
     },
+    "node_modules/ufo": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.3.tgz",
+      "integrity": "sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==",
+      "license": "MIT"
+    },
+    "node_modules/uint8arrays": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-3.1.1.tgz",
+      "integrity": "sha512-+QJa8QRnbdXVpHYjLoTpJIdCTiw9Ir62nocClWuXIq2JIh4Uta0cQsTSpFL678p2CN8B+XSApwcU+pQEqVpKWg==",
+      "license": "MIT",
+      "dependencies": {
+        "multiformats": "^9.4.2"
+      }
+    },
     "node_modules/unbox-primitive": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.1.0.tgz",
@@ -8651,6 +9554,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/uncrypto": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/uncrypto/-/uncrypto-0.1.3.tgz",
+      "integrity": "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==",
+      "license": "MIT"
     },
     "node_modules/undici-types": {
       "version": "7.16.0",
@@ -8692,6 +9601,111 @@
         "@unrs/resolver-binding-win32-arm64-msvc": "1.11.1",
         "@unrs/resolver-binding-win32-ia32-msvc": "1.11.1",
         "@unrs/resolver-binding-win32-x64-msvc": "1.11.1"
+      }
+    },
+    "node_modules/unstorage": {
+      "version": "1.17.5",
+      "resolved": "https://registry.npmjs.org/unstorage/-/unstorage-1.17.5.tgz",
+      "integrity": "sha512-0i3iqvRfx29hkNntHyQvJTpf5W9dQ9ZadSoRU8+xVlhVtT7jAX57fazYO9EHvcRCfBCyi5YRya7XCDOsbTgkPg==",
+      "license": "MIT",
+      "dependencies": {
+        "anymatch": "^3.1.3",
+        "chokidar": "^5.0.0",
+        "destr": "^2.0.5",
+        "h3": "^1.15.10",
+        "lru-cache": "^11.2.7",
+        "node-fetch-native": "^1.6.7",
+        "ofetch": "^1.5.1",
+        "ufo": "^1.6.3"
+      },
+      "peerDependencies": {
+        "@azure/app-configuration": "^1.8.0",
+        "@azure/cosmos": "^4.2.0",
+        "@azure/data-tables": "^13.3.0",
+        "@azure/identity": "^4.6.0",
+        "@azure/keyvault-secrets": "^4.9.0",
+        "@azure/storage-blob": "^12.26.0",
+        "@capacitor/preferences": "^6 || ^7 || ^8",
+        "@deno/kv": ">=0.9.0",
+        "@netlify/blobs": "^6.5.0 || ^7.0.0 || ^8.1.0 || ^9.0.0 || ^10.0.0",
+        "@planetscale/database": "^1.19.0",
+        "@upstash/redis": "^1.34.3",
+        "@vercel/blob": ">=0.27.1",
+        "@vercel/functions": "^2.2.12 || ^3.0.0",
+        "@vercel/kv": "^1 || ^2 || ^3",
+        "aws4fetch": "^1.0.20",
+        "db0": ">=0.2.1",
+        "idb-keyval": "^6.2.1",
+        "ioredis": "^5.4.2",
+        "uploadthing": "^7.4.4"
+      },
+      "peerDependenciesMeta": {
+        "@azure/app-configuration": {
+          "optional": true
+        },
+        "@azure/cosmos": {
+          "optional": true
+        },
+        "@azure/data-tables": {
+          "optional": true
+        },
+        "@azure/identity": {
+          "optional": true
+        },
+        "@azure/keyvault-secrets": {
+          "optional": true
+        },
+        "@azure/storage-blob": {
+          "optional": true
+        },
+        "@capacitor/preferences": {
+          "optional": true
+        },
+        "@deno/kv": {
+          "optional": true
+        },
+        "@netlify/blobs": {
+          "optional": true
+        },
+        "@planetscale/database": {
+          "optional": true
+        },
+        "@upstash/redis": {
+          "optional": true
+        },
+        "@vercel/blob": {
+          "optional": true
+        },
+        "@vercel/functions": {
+          "optional": true
+        },
+        "@vercel/kv": {
+          "optional": true
+        },
+        "aws4fetch": {
+          "optional": true
+        },
+        "db0": {
+          "optional": true
+        },
+        "idb-keyval": {
+          "optional": true
+        },
+        "ioredis": {
+          "optional": true
+        },
+        "uploadthing": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/unstorage/node_modules/lru-cache": {
+      "version": "11.3.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
+      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/update-browserslist-db": {
@@ -8999,6 +10013,27 @@
       },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/ws": {
+      "version": "7.5.10",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/xdg-basedir": {

--- a/package.json
+++ b/package.json
@@ -23,13 +23,11 @@
     "test:coverage": "cross-env NODE_OPTIONS=--experimental-vm-modules jest --coverage"
   },
   "dependencies": {
-    "@json-rpc-tools/utils": "^1.7.6",
     "@reown/walletkit": "^1.5.5",
     "@walletconnect/pay": "^1.0.8",
     "@tetherto/wdk-wallet": "^1.0.0-beta.6",
     "@walletconnect/utils": "^2.23.9",
-    "bare-node-runtime": "^1.1.4",
-    "tslib": "^2.8.1"
+    "bare-node-runtime": "^1.1.4"
   },
   "devDependencies": {
     "@walletconnect/sign-client": "^2.23.9",

--- a/package.json
+++ b/package.json
@@ -23,11 +23,18 @@
     "test:coverage": "cross-env NODE_OPTIONS=--experimental-vm-modules jest --coverage"
   },
   "dependencies": {
+    "@json-rpc-tools/utils": "^1.7.6",
+    "@reown/walletkit": "^1.5.5",
+    "@walletconnect/pay": "^1.0.8",
     "@tetherto/wdk-wallet": "^1.0.0-beta.6",
-    "bare-node-runtime": "^1.1.4"
+    "@walletconnect/utils": "^2.23.9",
+    "bare-node-runtime": "^1.1.4",
+    "tslib": "^2.8.1"
   },
   "devDependencies": {
+    "@walletconnect/sign-client": "^2.23.9",
     "cross-env": "7.0.3",
+    "dotenv": "^17.4.2",
     "jest": "30.1.3",
     "standard": "17.1.2",
     "typescript": "5.8.3"

--- a/src/walletconnect-handler.js
+++ b/src/walletconnect-handler.js
@@ -3,7 +3,14 @@
 import { WalletKit, isPaymentLink } from '@reown/walletkit'
 import { Core } from '@walletconnect/core'
 import { getSdkError } from '@walletconnect/utils'
-import { formatJsonRpcResult, formatJsonRpcError } from '@json-rpc-tools/utils'
+
+function formatJsonRpcResult (id, result) {
+  return { id, jsonrpc: '2.0', result }
+}
+
+function formatJsonRpcError (id, message) {
+  return { id, jsonrpc: '2.0', error: { code: -32000, message } }
+}
 
 /**
  * @typedef {import('events').EventEmitter} EventEmitter

--- a/src/walletconnect-handler.js
+++ b/src/walletconnect-handler.js
@@ -1,0 +1,271 @@
+'use strict'
+
+import { WalletKit, isPaymentLink } from '@reown/walletkit'
+import { Core } from '@walletconnect/core'
+import { getSdkError } from '@walletconnect/utils'
+import { formatJsonRpcResult, formatJsonRpcError } from '@json-rpc-tools/utils'
+
+/**
+ * @typedef {import('events').EventEmitter} EventEmitter
+ */
+
+/**
+ * @typedef {object} WalletConnectConfig
+ * @property {string} projectId
+ * @property {{ name: string, description: string, url: string, icons: string[] }} metadata
+ * @property {string} [relayUrl]
+ * @property {{ appId: string, apiKey?: string, baseUrl?: string }} [payConfig]
+ * @property {object} [signConfig]
+ */
+
+/**
+ * Thin wrapper around WalletKit that forwards events to an external EventEmitter
+ * and exposes passthrough methods. No internal signing or request processing.
+ */
+export default class WalletConnectHandler {
+  /**
+   * @param {EventEmitter} emitter
+   */
+  constructor (emitter) {
+    /** @private */
+    this._emitter = emitter
+
+    /** @private */
+    this._walletkit = null
+  }
+
+  /**
+   * @param {WalletConnectConfig} config
+   */
+  async init (config) {
+    const core = new Core({
+      projectId: config.projectId,
+      relayUrl: config.relayUrl
+    })
+    this._walletkit = await WalletKit.init({
+      core,
+      metadata: config.metadata,
+      signConfig: config.signConfig ?? { disableRequestQueue: true },
+      payConfig: config.payConfig
+    })
+
+    this._subscribeToEvents()
+  }
+
+  /**
+   * @returns {import('@reown/walletkit').WalletKit | null}
+   */
+  get walletkit () {
+    return this._walletkit ?? null
+  }
+
+  /**
+   * @returns {import('@reown/walletkit').IWalletKitPay | null}
+   */
+  get pay () {
+    return this._walletkit?.pay ?? null
+  }
+
+  /**
+   * @param {string} uri
+   */
+  async pair (uri) {
+    this._ensureInitialized()
+
+    if (isPaymentLink(uri)) {
+      this._emitter.emit('payment_link', { uri })
+      return
+    }
+
+    await this._walletkit.pair({ uri })
+  }
+
+  /**
+   * Passthrough to walletkit.approveSession.
+   *
+   * @param {object} params
+   * @param {number} params.id
+   * @param {Record<string, object>} params.namespaces
+   * @param {object} [params.sessionProperties]
+   * @param {object} [params.scopedProperties]
+   * @param {object} [params.sessionConfig]
+   * @param {string} [params.relayProtocol]
+   * @param {object} [params.proposalRequestsResponses]
+   * @returns {Promise<object>}
+   */
+  async approveSession (params) {
+    this._ensureInitialized()
+    return this._walletkit.approveSession(params)
+  }
+
+  /**
+   * @param {number} id
+   */
+  async rejectSession (id) {
+    this._ensureInitialized()
+    await this._walletkit.rejectSession({
+      id,
+      reason: getSdkError('USER_REJECTED')
+    })
+  }
+
+  /**
+   * @param {number} id
+   * @param {string} topic
+   * @param {object} params
+   * @param {*} params.result
+   */
+  async respondRequest (id, topic, { result }) {
+    this._ensureInitialized()
+    await this._walletkit.respondSessionRequest({
+      topic,
+      response: formatJsonRpcResult(id, result)
+    })
+  }
+
+  /**
+   * @param {number} id
+   * @param {string} topic
+   * @param {string} [message]
+   */
+  async rejectRequest (id, topic, message) {
+    this._ensureInitialized()
+    await this._walletkit.respondSessionRequest({
+      topic,
+      response: formatJsonRpcError(id, message ?? getSdkError('USER_REJECTED').message)
+    })
+  }
+
+  /**
+   * @returns {Record<string, object>}
+   */
+  getSessions () {
+    this._ensureInitialized()
+    return this._walletkit.getActiveSessions()
+  }
+
+  /**
+   * @returns {Record<number, object>}
+   */
+  getPendingSessionProposals () {
+    this._ensureInitialized()
+    return this._walletkit.getPendingSessionProposals()
+  }
+
+  /**
+   * @returns {object[]}
+   */
+  getPendingSessionRequests () {
+    this._ensureInitialized()
+    return this._walletkit.getPendingSessionRequests()
+  }
+
+  /**
+   * @param {string} topic
+   */
+  async disconnectSession (topic) {
+    this._ensureInitialized()
+    await this._walletkit.disconnectSession({
+      topic,
+      reason: getSdkError('USER_DISCONNECTED')
+    })
+  }
+
+  /**
+   * @param {object} params
+   * @param {string} params.topic
+   * @param {Record<string, object>} params.namespaces
+   */
+  async updateSession (params) {
+    this._ensureInitialized()
+    return this._walletkit.updateSession(params)
+  }
+
+  /**
+   * @param {object} params
+   * @param {string} params.topic
+   */
+  async extendSession (params) {
+    this._ensureInitialized()
+    return this._walletkit.extendSession(params)
+  }
+
+  /**
+   * @param {object} params
+   * @param {string} params.topic
+   * @param {*} params.event
+   * @param {string} params.chainId
+   */
+  async emitSessionEvent (params) {
+    this._ensureInitialized()
+    await this._walletkit.emitSessionEvent(params)
+  }
+
+  /**
+   * @param {object} params
+   */
+  async approveSessionAuthenticate (params) {
+    this._ensureInitialized()
+    return this._walletkit.approveSessionAuthenticate(params)
+  }
+
+  /**
+   * @param {object} params
+   * @param {number} params.id
+   */
+  async rejectSessionAuthenticate (params) {
+    this._ensureInitialized()
+    await this._walletkit.rejectSessionAuthenticate({
+      id: params.id,
+      reason: getSdkError('USER_REJECTED')
+    })
+  }
+
+  /**
+   * @param {object} params
+   * @param {{ request: object, iss: string }} params
+   * @returns {string}
+   */
+  formatAuthMessage (params) {
+    this._ensureInitialized()
+    return this._walletkit.formatAuthMessage(params)
+  }
+
+  dispose () {
+    this._walletkit = null
+  }
+
+  /** @private */
+  _ensureInitialized () {
+    if (!this._walletkit) {
+      throw new Error('WalletConnect not initialized. Call initWalletConnect() first.')
+    }
+  }
+
+  /** @private */
+  _subscribeToEvents () {
+    this._walletkit.on('session_proposal', (payload) => {
+      this._emitter.emit('session_proposal', payload)
+    })
+
+    this._walletkit.on('session_request', (payload) => {
+      this._emitter.emit('session_request', payload)
+    })
+
+    this._walletkit.on('session_delete', (payload) => {
+      this._emitter.emit('session_delete', payload)
+    })
+
+    this._walletkit.on('session_authenticate', (payload) => {
+      this._emitter.emit('session_authenticate', payload)
+    })
+
+    this._walletkit.on('proposal_expire', (payload) => {
+      this._emitter.emit('proposal_expire', payload)
+    })
+
+    this._walletkit.on('session_request_expire', (payload) => {
+      this._emitter.emit('session_request_expire', payload)
+    })
+  }
+}

--- a/src/wdk-manager.js
+++ b/src/wdk-manager.js
@@ -14,9 +14,13 @@
 
 'use strict'
 
+import { EventEmitter } from 'events'
+
 import WalletManager from '@tetherto/wdk-wallet'
 
 import { SwapProtocol, BridgeProtocol, LendingProtocol, FiatProtocol } from '@tetherto/wdk-wallet/protocols'
+
+import WalletConnectHandler from './walletconnect-handler.js'
 
 /** @typedef {import('@tetherto/wdk-wallet').IWalletAccount} IWalletAccount */
 
@@ -24,9 +28,11 @@ import { SwapProtocol, BridgeProtocol, LendingProtocol, FiatProtocol } from '@te
 
 /** @typedef {import('./wallet-account-with-protocols.js').IWalletAccountWithProtocols} IWalletAccountWithProtocols */
 
+/** @typedef {import('./walletconnect-handler.js').WalletConnectConfig} WalletConnectConfig */
+
 /** @typedef {<A extends IWalletAccount>(account: A) => Promise<void>} MiddlewareFunction */
 
-export default class WDK {
+export default class WDK extends EventEmitter {
   /**
    * Creates a new wallet development kit instance.
    *
@@ -34,6 +40,8 @@ export default class WDK {
    * @throws {Error} If the seed is not valid.
    */
   constructor (seed) {
+    super()
+
     if (!WDK.isValidSeed(seed)) {
       throw new Error('Invalid seed.')
     }
@@ -49,6 +57,9 @@ export default class WDK {
 
     /** @private */
     this._middlewares = { }
+
+    /** @private */
+    this._wc = new WalletConnectHandler(this)
   }
 
   /**
@@ -212,11 +223,216 @@ export default class WDK {
   }
 
   /**
+   * Initializes WalletConnect (WalletKit) and subscribes to session events.
+   * Events are emitted on this WDK instance: session_proposal, session_request,
+   * session_delete, session_authenticate, proposal_expire, session_request_expire, payment_link.
+   *
+   * @param {WalletConnectConfig} config
+   * @returns {Promise<WDK>}
+   */
+  async initWalletConnect (config) {
+    await this._wc.init(config)
+
+    return this
+  }
+
+  /**
+   * The underlying WalletKit instance. Available after initWalletConnect.
+   *
+   * @returns {import('@reown/walletkit').WalletKit | null}
+   */
+  get walletkit () {
+    return this._wc.walletkit
+  }
+
+  /**
+   * The WalletConnect Pay client. Available after initWalletConnect with payConfig.
+   *
+   * @returns {import('@reown/walletkit').IWalletKitPay | null}
+   */
+  get pay () {
+    return this._wc.pay
+  }
+
+  /**
+   * Pairs with a dApp via URI or detects a payment link.
+   * Payment links emit a 'payment_link' event instead of pairing.
+   *
+   * @param {string} uri
+   * @returns {Promise<void>}
+   */
+  async pair (uri) {
+    await this._wc.pair(uri)
+  }
+
+  /**
+   * Approves a session proposal. Passthrough to WalletKit — all params are forwarded as-is.
+   *
+   * @param {object} params
+   * @param {number} params.id
+   * @param {Record<string, object>} params.namespaces
+   * @param {object} [params.sessionProperties]
+   * @param {object} [params.scopedProperties]
+   * @param {object} [params.sessionConfig]
+   * @param {string} [params.relayProtocol]
+   * @param {object} [params.proposalRequestsResponses]
+   * @returns {Promise<object>} The session.
+   */
+  async approveSession (params) {
+    return this._wc.approveSession(params)
+  }
+
+  /**
+   * Rejects a session proposal.
+   *
+   * @param {number} id
+   * @returns {Promise<void>}
+   */
+  async rejectSession (id) {
+    await this._wc.rejectSession(id)
+  }
+
+  /**
+   * Responds to a session request with a result provided by the consumer.
+   *
+   * @param {number} id
+   * @param {string} topic
+   * @param {object} params
+   * @param {*} params.result
+   * @returns {Promise<void>}
+   */
+  async respondRequest (id, topic, { result }) {
+    await this._wc.respondRequest(id, topic, { result })
+  }
+
+  /**
+   * Rejects a session request.
+   *
+   * @param {number} id
+   * @param {string} topic
+   * @param {string} [message]
+   * @returns {Promise<void>}
+   */
+  async rejectRequest (id, topic, message) {
+    await this._wc.rejectRequest(id, topic, message)
+  }
+
+  /**
+   * Returns all active WalletConnect sessions.
+   *
+   * @returns {Record<string, object>}
+   */
+  getSessions () {
+    return this._wc.getSessions()
+  }
+
+  /**
+   * Returns all pending session proposals.
+   *
+   * @returns {Record<number, object>}
+   */
+  getPendingSessionProposals () {
+    return this._wc.getPendingSessionProposals()
+  }
+
+  /**
+   * Returns all pending session requests.
+   *
+   * @returns {object[]}
+   */
+  getPendingSessionRequests () {
+    return this._wc.getPendingSessionRequests()
+  }
+
+  /**
+   * Disconnects a WalletConnect session.
+   *
+   * @param {string} topic
+   * @returns {Promise<void>}
+   */
+  async disconnectSession (topic) {
+    await this._wc.disconnectSession(topic)
+  }
+
+  /**
+   * Updates a session's namespaces.
+   *
+   * @param {object} params
+   * @param {string} params.topic
+   * @param {Record<string, object>} params.namespaces
+   * @returns {Promise<{ acknowledged: () => Promise<void> }>}
+   */
+  async updateSession (params) {
+    return this._wc.updateSession(params)
+  }
+
+  /**
+   * Extends a session's expiry.
+   *
+   * @param {object} params
+   * @param {string} params.topic
+   * @returns {Promise<{ acknowledged: () => Promise<void> }>}
+   */
+  async extendSession (params) {
+    return this._wc.extendSession(params)
+  }
+
+  /**
+   * Emits an event to a connected dApp.
+   *
+   * @param {object} params
+   * @param {string} params.topic
+   * @param {*} params.event
+   * @param {string} params.chainId
+   * @returns {Promise<void>}
+   */
+  async emitSessionEvent (params) {
+    await this._wc.emitSessionEvent(params)
+  }
+
+  /**
+   * Approves a standalone session authentication request.
+   *
+   * @param {object} params
+   * @returns {Promise<{ session: object | undefined }>}
+   */
+  async approveSessionAuthenticate (params) {
+    return this._wc.approveSessionAuthenticate(params)
+  }
+
+  /**
+   * Rejects a standalone session authentication request.
+   *
+   * @param {object} params
+   * @param {number} params.id
+   * @returns {Promise<void>}
+   */
+  async rejectSessionAuthenticate (params) {
+    await this._wc.rejectSessionAuthenticate(params)
+  }
+
+  /**
+   * Formats an authentication message for signing.
+   *
+   * @param {object} params
+   * @param {object} params.request
+   * @param {string} params.iss
+   * @returns {string}
+   */
+  formatAuthMessage (params) {
+    return this._wc.formatAuthMessage(params)
+  }
+
+  /**
    * Disposes and unregisters wallets, erasing any sensitive data from memory.
    * If no blockchains are specified, all registered wallets are disposed.
+   * WalletConnect sessions should be disconnected explicitly via disconnectSession() before calling dispose.
+   *
    * @param {string[]} [blockchains] - The blockchains to dispose. If omitted, all wallets are disposed.
    */
   dispose (blockchains) {
+    this._wc.dispose()
+
     for (const [blockchain, wallet] of this._wallets) {
       if (!blockchains || blockchains.includes(blockchain)) {
         wallet.dispose()

--- a/tests/walletconnect-e2e.test.js
+++ b/tests/walletconnect-e2e.test.js
@@ -1,0 +1,235 @@
+'use strict'
+
+import dotenv from 'dotenv'
+import { afterAll, beforeAll, describe, expect, test, jest } from '@jest/globals'
+import { SignClient } from '@walletconnect/sign-client'
+import { Core } from '@walletconnect/core'
+
+import WDK from '../index.js'
+
+dotenv.config()
+
+const WALLETCONNECT_PROJECT_ID = process.env.WALLETCONNECT_PROJECT_ID
+const describeE2E = WALLETCONNECT_PROJECT_ID ? describe : describe.skip
+
+const WALLET_METADATA = {
+  name: 'WDK E2E Wallet',
+  description: 'E2E test wallet',
+  url: 'https://wdk-test.example.com',
+  icons: ['https://wdk-test.example.com/icon.png']
+}
+
+const DAPP_METADATA = {
+  name: 'WDK E2E dApp',
+  description: 'E2E test dApp',
+  url: 'https://dapp-test.example.com',
+  icons: ['https://dapp-test.example.com/icon.png']
+}
+
+const OPTIONAL_NAMESPACES = {
+  eip155: {
+    methods: ['personal_sign'],
+    chains: ['eip155:1'],
+    events: ['chainChanged', 'accountsChanged']
+  }
+}
+
+const TEST_ACCOUNT = 'eip155:1:0x1234567890abcdef1234567890abcdef12345678'
+
+function buildApprovedNamespaces () {
+  return {
+    eip155: {
+      accounts: [TEST_ACCOUNT],
+      methods: ['personal_sign'],
+      events: ['chainChanged', 'accountsChanged']
+    }
+  }
+}
+
+function waitForEvent (emitter, event, timeoutMs = 15000) {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error(`Timed out waiting for "${event}"`)), timeoutMs)
+    emitter.once(event, (payload) => {
+      clearTimeout(timer)
+      resolve(payload)
+    })
+  })
+}
+
+describeE2E('WalletConnect E2E', () => {
+  let wdk
+  let signClient
+
+  beforeAll(async () => {
+    const seed = WDK.getRandomSeedPhrase()
+    wdk = new WDK(seed)
+
+    await wdk.initWalletConnect({
+      projectId: WALLETCONNECT_PROJECT_ID,
+      metadata: WALLET_METADATA
+    })
+
+    // Clear the global Core singleton so the dApp gets its own independent
+    // Core and relay connection (in production they'd be separate processes).
+    delete globalThis._walletConnectCore_
+    delete globalThis._walletConnectCore__count
+
+    const dappCore = new Core({
+      projectId: WALLETCONNECT_PROJECT_ID
+    })
+
+    signClient = await SignClient.init({
+      core: dappCore,
+      metadata: DAPP_METADATA
+    })
+  }, 30000)
+
+  afterAll(async () => {
+    const spy = jest.spyOn(console, 'error').mockImplementation(() => {})
+    try {
+      const sessions = signClient.session.getAll()
+      for (const session of sessions) {
+        await signClient.disconnect({
+          topic: session.topic,
+          reason: { code: 6000, message: 'test cleanup' }
+        }).catch(() => {})
+      }
+    } catch (_) {}
+
+    wdk.dispose()
+    spy.mockRestore()
+  }, 15000)
+
+  test('should initialize without error and have no sessions', () => {
+    // #given / #when — init happened in beforeAll
+
+    // #then
+    const sessions = wdk.getSessions()
+    expect(Object.keys(sessions)).toHaveLength(0)
+  })
+
+  test('full session lifecycle: pair, approve, request, respond, disconnect', async () => {
+    // #given — dApp initiates connection
+    const { uri, approval } = await signClient.connect({
+      optionalNamespaces: OPTIONAL_NAMESPACES
+    })
+
+    // #when — wallet pairs and auto-approves the proposal
+    const proposalPromise = waitForEvent(wdk, 'session_proposal')
+    await wdk.pair(uri)
+
+    const proposal = await proposalPromise
+    await wdk.approveSession({
+      id: proposal.id,
+      namespaces: buildApprovedNamespaces()
+    })
+
+    const session = await approval()
+
+    // #then — session is established on both sides
+    expect(session.topic).toBeDefined()
+    const wdkSessions = wdk.getSessions()
+    expect(wdkSessions[session.topic]).toBeDefined()
+
+    // #when — dApp sends a personal_sign request
+    const requestPromise = waitForEvent(wdk, 'session_request')
+    const FAKE_SIGNATURE = '0xdeadbeef'
+
+    const resultPromise = signClient.request({
+      topic: session.topic,
+      chainId: 'eip155:1',
+      request: {
+        method: 'personal_sign',
+        params: ['0x48656c6c6f', TEST_ACCOUNT]
+      }
+    })
+
+    const request = await requestPromise
+
+    // #then — request is received with correct method
+    expect(request.params.request.method).toBe('personal_sign')
+
+    // #when — wallet responds
+    await wdk.respondRequest(request.id, request.topic, { result: FAKE_SIGNATURE })
+
+    // #then — dApp receives the signature
+    const result = await resultPromise
+    expect(result).toBe(FAKE_SIGNATURE)
+
+    // #when — dApp disconnects
+    const deletePromise = waitForEvent(wdk, 'session_delete')
+    await signClient.disconnect({
+      topic: session.topic,
+      reason: { code: 6000, message: 'test done' }
+    })
+
+    // #then — wallet receives session_delete
+    const deleteEvent = await deletePromise
+    expect(deleteEvent.topic).toBe(session.topic)
+    
+  }, 30000)
+
+  test('reject session: dApp should receive rejection', async () => {
+    // #given
+    const { uri, approval } = await signClient.connect({
+      optionalNamespaces: OPTIONAL_NAMESPACES
+    })
+
+    // #when — wallet pairs and rejects
+    const proposalPromise = waitForEvent(wdk, 'session_proposal')
+    await wdk.pair(uri)
+
+    const proposal = await proposalPromise
+    await wdk.rejectSession(proposal.id)
+
+    // #then — dApp approval should reject
+    await expect(approval()).rejects.toBeDefined()
+  }, 30000)
+
+  test('reject request: dApp should receive error', async () => {
+    // #given — establish a session
+    const { uri, approval } = await signClient.connect({
+      optionalNamespaces: OPTIONAL_NAMESPACES
+    })
+
+    const proposalPromise = waitForEvent(wdk, 'session_proposal')
+    await wdk.pair(uri)
+
+    const proposal = await proposalPromise
+    await wdk.approveSession({
+      id: proposal.id,
+      namespaces: buildApprovedNamespaces()
+    })
+
+    const session = await approval()
+
+    // #when — dApp sends request and wallet rejects it
+    const requestPromise = waitForEvent(wdk, 'session_request')
+
+    const resultPromise = signClient.request({
+      topic: session.topic,
+      chainId: 'eip155:1',
+      request: {
+        method: 'personal_sign',
+        params: ['0x48656c6c6f', TEST_ACCOUNT]
+      }
+    })
+
+    const request = await requestPromise
+    await wdk.rejectRequest(request.id, request.topic, 'User declined')
+
+    // #then — dApp should receive an error
+    const spy = jest.spyOn(console, 'error').mockImplementation(() => {})
+    try {
+      await expect(resultPromise).rejects.toBeDefined()
+    } finally {
+      spy.mockRestore()
+    }
+
+    // cleanup
+    await signClient.disconnect({
+      topic: session.topic,
+      reason: { code: 6000, message: 'test cleanup' }
+    }).catch(() => {})
+  }, 30000)
+})

--- a/tests/walletconnect-handler.test.js
+++ b/tests/walletconnect-handler.test.js
@@ -37,13 +37,7 @@ jest.unstable_mockModule('@walletconnect/utils', () => ({
   getSdkError: jest.fn((type) => ({ message: type, code: 0 }))
 }))
 
-jest.unstable_mockModule('@json-rpc-tools/utils', () => ({
-  formatJsonRpcResult: jest.fn((id, result) => ({ id, result, jsonrpc: '2.0' })),
-  formatJsonRpcError: jest.fn((id, message) => ({ id, error: { message }, jsonrpc: '2.0' }))
-}))
-
 const { default: WalletConnectHandler } = await import('../src/walletconnect-handler.js')
-const { formatJsonRpcResult, formatJsonRpcError } = await import('@json-rpc-tools/utils')
 
 describe('WalletConnectHandler', () => {
   let handler
@@ -177,10 +171,9 @@ describe('WalletConnectHandler', () => {
       await handler.respondRequest(1, 'topic-1', { result })
 
       // #then
-      expect(formatJsonRpcResult).toHaveBeenCalledWith(1, '0xsignature')
       expect(mockWalletKitInstance.respondSessionRequest).toHaveBeenCalledWith({
         topic: 'topic-1',
-        response: { id: 1, result: '0xsignature', jsonrpc: '2.0' }
+        response: { id: 1, jsonrpc: '2.0', result: '0xsignature' }
       })
     })
   })
@@ -195,10 +188,9 @@ describe('WalletConnectHandler', () => {
       await handler.rejectRequest(1, 'topic-1')
 
       // #then
-      expect(formatJsonRpcError).toHaveBeenCalledWith(1, 'USER_REJECTED')
       expect(mockWalletKitInstance.respondSessionRequest).toHaveBeenCalledWith({
         topic: 'topic-1',
-        response: expect.objectContaining({ id: 1 })
+        response: { id: 1, jsonrpc: '2.0', error: { code: -32000, message: 'USER_REJECTED' } }
       })
     })
 
@@ -207,7 +199,10 @@ describe('WalletConnectHandler', () => {
       await handler.rejectRequest(1, 'topic-1', 'custom error')
 
       // #then
-      expect(formatJsonRpcError).toHaveBeenCalledWith(1, 'custom error')
+      expect(mockWalletKitInstance.respondSessionRequest).toHaveBeenCalledWith({
+        topic: 'topic-1',
+        response: { id: 1, jsonrpc: '2.0', error: { code: -32000, message: 'custom error' } }
+      })
     })
   })
 

--- a/tests/walletconnect-handler.test.js
+++ b/tests/walletconnect-handler.test.js
@@ -1,0 +1,388 @@
+'use strict'
+
+import { beforeEach, describe, expect, jest, test } from '@jest/globals'
+import { EventEmitter } from 'events'
+
+const mockWalletKitInstance = {
+  on: jest.fn(),
+  pair: jest.fn(),
+  approveSession: jest.fn(),
+  rejectSession: jest.fn(),
+  respondSessionRequest: jest.fn(),
+  getActiveSessions: jest.fn(),
+  getPendingSessionProposals: jest.fn(),
+  getPendingSessionRequests: jest.fn(),
+  disconnectSession: jest.fn(),
+  updateSession: jest.fn(),
+  extendSession: jest.fn(),
+  emitSessionEvent: jest.fn(),
+  approveSessionAuthenticate: jest.fn(),
+  rejectSessionAuthenticate: jest.fn(),
+  formatAuthMessage: jest.fn(),
+  pay: { getPaymentOptions: jest.fn() }
+}
+
+jest.unstable_mockModule('@reown/walletkit', () => ({
+  WalletKit: {
+    init: jest.fn().mockResolvedValue(mockWalletKitInstance)
+  },
+  isPaymentLink: jest.fn((uri) => uri.startsWith('wc:pay'))
+}))
+
+jest.unstable_mockModule('@walletconnect/core', () => ({
+  Core: jest.fn()
+}))
+
+jest.unstable_mockModule('@walletconnect/utils', () => ({
+  getSdkError: jest.fn((type) => ({ message: type, code: 0 }))
+}))
+
+jest.unstable_mockModule('@json-rpc-tools/utils', () => ({
+  formatJsonRpcResult: jest.fn((id, result) => ({ id, result, jsonrpc: '2.0' })),
+  formatJsonRpcError: jest.fn((id, message) => ({ id, error: { message }, jsonrpc: '2.0' }))
+}))
+
+const { default: WalletConnectHandler } = await import('../src/walletconnect-handler.js')
+const { formatJsonRpcResult, formatJsonRpcError } = await import('@json-rpc-tools/utils')
+
+describe('WalletConnectHandler', () => {
+  let handler
+  let emitter
+
+  const CONFIG = {
+    projectId: 'test-project-id',
+    metadata: {
+      name: 'Test',
+      description: 'Test wallet',
+      url: 'https://test.com',
+      icons: ['https://test.com/icon.png']
+    }
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    emitter = new EventEmitter()
+    handler = new WalletConnectHandler(emitter)
+  })
+
+  describe('init', () => {
+    test('should initialize WalletKit and subscribe to events', async () => {
+      await handler.init(CONFIG)
+
+      expect(mockWalletKitInstance.on).toHaveBeenCalledWith('session_proposal', expect.any(Function))
+      expect(mockWalletKitInstance.on).toHaveBeenCalledWith('session_request', expect.any(Function))
+      expect(mockWalletKitInstance.on).toHaveBeenCalledWith('session_delete', expect.any(Function))
+      expect(mockWalletKitInstance.on).toHaveBeenCalledWith('session_authenticate', expect.any(Function))
+      expect(mockWalletKitInstance.on).toHaveBeenCalledWith('proposal_expire', expect.any(Function))
+      expect(mockWalletKitInstance.on).toHaveBeenCalledWith('session_request_expire', expect.any(Function))
+    })
+  })
+
+  describe('walletkit getter', () => {
+    test('should return null before init', () => {
+      expect(handler.walletkit).toBeNull()
+    })
+
+    test('should return the walletkit instance after init', async () => {
+      await handler.init(CONFIG)
+      expect(handler.walletkit).toBe(mockWalletKitInstance)
+    })
+  })
+
+  describe('before init', () => {
+    test('should throw when calling methods before init', async () => {
+      await expect(handler.pair('wc:test')).rejects.toThrow('WalletConnect not initialized')
+      expect(() => handler.getSessions()).toThrow('WalletConnect not initialized')
+    })
+  })
+
+  describe('pair', () => {
+    beforeEach(async () => {
+      await handler.init(CONFIG)
+    })
+
+    test('should call walletkit.pair for regular URIs', async () => {
+      // #given
+      const uri = 'wc:abc123@2?relay-protocol=irn'
+
+      // #when
+      await handler.pair(uri)
+
+      // #then
+      expect(mockWalletKitInstance.pair).toHaveBeenCalledWith({ uri })
+    })
+
+    test('should emit payment_link for payment URIs', async () => {
+      // #given
+      const uri = 'wc:pay-link-123'
+      const listener = jest.fn()
+      emitter.on('payment_link', listener)
+
+      // #when
+      await handler.pair(uri)
+
+      // #then
+      expect(listener).toHaveBeenCalledWith({ uri })
+      expect(mockWalletKitInstance.pair).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('approveSession', () => {
+    beforeEach(async () => {
+      await handler.init(CONFIG)
+    })
+
+    test('should passthrough params to walletkit.approveSession', async () => {
+      // #given
+      const params = {
+        id: 1,
+        namespaces: { eip155: { accounts: ['eip155:1:0xabc'], methods: ['personal_sign'], events: [] } }
+      }
+
+      // #when
+      await handler.approveSession(params)
+
+      // #then
+      expect(mockWalletKitInstance.approveSession).toHaveBeenCalledWith(params)
+    })
+  })
+
+  describe('rejectSession', () => {
+    beforeEach(async () => {
+      await handler.init(CONFIG)
+    })
+
+    test('should reject with USER_REJECTED reason', async () => {
+      // #when
+      await handler.rejectSession(42)
+
+      // #then
+      expect(mockWalletKitInstance.rejectSession).toHaveBeenCalledWith({
+        id: 42,
+        reason: { message: 'USER_REJECTED', code: 0 }
+      })
+    })
+  })
+
+  describe('respondRequest', () => {
+    beforeEach(async () => {
+      await handler.init(CONFIG)
+    })
+
+    test('should format and forward the result', async () => {
+      // #given
+      const result = '0xsignature'
+
+      // #when
+      await handler.respondRequest(1, 'topic-1', { result })
+
+      // #then
+      expect(formatJsonRpcResult).toHaveBeenCalledWith(1, '0xsignature')
+      expect(mockWalletKitInstance.respondSessionRequest).toHaveBeenCalledWith({
+        topic: 'topic-1',
+        response: { id: 1, result: '0xsignature', jsonrpc: '2.0' }
+      })
+    })
+  })
+
+  describe('rejectRequest', () => {
+    beforeEach(async () => {
+      await handler.init(CONFIG)
+    })
+
+    test('should format and forward an error', async () => {
+      // #when
+      await handler.rejectRequest(1, 'topic-1')
+
+      // #then
+      expect(formatJsonRpcError).toHaveBeenCalledWith(1, 'USER_REJECTED')
+      expect(mockWalletKitInstance.respondSessionRequest).toHaveBeenCalledWith({
+        topic: 'topic-1',
+        response: expect.objectContaining({ id: 1 })
+      })
+    })
+
+    test('should use custom message when provided', async () => {
+      // #when
+      await handler.rejectRequest(1, 'topic-1', 'custom error')
+
+      // #then
+      expect(formatJsonRpcError).toHaveBeenCalledWith(1, 'custom error')
+    })
+  })
+
+  describe('session management', () => {
+    beforeEach(async () => {
+      await handler.init(CONFIG)
+    })
+
+    test('getSessions should return active sessions', () => {
+      // #given
+      const sessions = { 'topic-1': { peer: {} } }
+      mockWalletKitInstance.getActiveSessions.mockReturnValue(sessions)
+
+      // #when / #then
+      expect(handler.getSessions()).toBe(sessions)
+    })
+
+    test('getPendingSessionProposals should return pending proposals', () => {
+      // #given
+      const proposals = { 1: { id: 1 } }
+      mockWalletKitInstance.getPendingSessionProposals.mockReturnValue(proposals)
+
+      // #when / #then
+      expect(handler.getPendingSessionProposals()).toBe(proposals)
+    })
+
+    test('getPendingSessionRequests should return pending requests', () => {
+      // #given
+      const requests = [{ id: 1 }]
+      mockWalletKitInstance.getPendingSessionRequests.mockReturnValue(requests)
+
+      // #when / #then
+      expect(handler.getPendingSessionRequests()).toBe(requests)
+    })
+
+    test('disconnectSession should disconnect with USER_DISCONNECTED', async () => {
+      // #when
+      await handler.disconnectSession('topic-1')
+
+      // #then
+      expect(mockWalletKitInstance.disconnectSession).toHaveBeenCalledWith({
+        topic: 'topic-1',
+        reason: { message: 'USER_DISCONNECTED', code: 0 }
+      })
+    })
+
+    test('updateSession should passthrough params', async () => {
+      // #given
+      const params = { topic: 'topic-1', namespaces: {} }
+
+      // #when
+      await handler.updateSession(params)
+
+      // #then
+      expect(mockWalletKitInstance.updateSession).toHaveBeenCalledWith(params)
+    })
+
+    test('extendSession should passthrough params', async () => {
+      // #given
+      const params = { topic: 'topic-1' }
+
+      // #when
+      await handler.extendSession(params)
+
+      // #then
+      expect(mockWalletKitInstance.extendSession).toHaveBeenCalledWith(params)
+    })
+
+    test('emitSessionEvent should passthrough params', async () => {
+      // #given
+      const params = { topic: 'topic-1', event: { name: 'accountsChanged' }, chainId: 'eip155:1' }
+
+      // #when
+      await handler.emitSessionEvent(params)
+
+      // #then
+      expect(mockWalletKitInstance.emitSessionEvent).toHaveBeenCalledWith(params)
+    })
+  })
+
+  describe('auth', () => {
+    beforeEach(async () => {
+      await handler.init(CONFIG)
+    })
+
+    test('approveSessionAuthenticate should passthrough params', async () => {
+      // #given
+      const params = { id: 1, auths: [] }
+
+      // #when
+      await handler.approveSessionAuthenticate(params)
+
+      // #then
+      expect(mockWalletKitInstance.approveSessionAuthenticate).toHaveBeenCalledWith(params)
+    })
+
+    test('rejectSessionAuthenticate should reject with USER_REJECTED', async () => {
+      // #when
+      await handler.rejectSessionAuthenticate({ id: 1 })
+
+      // #then
+      expect(mockWalletKitInstance.rejectSessionAuthenticate).toHaveBeenCalledWith({
+        id: 1,
+        reason: { message: 'USER_REJECTED', code: 0 }
+      })
+    })
+
+    test('formatAuthMessage should passthrough params', () => {
+      // #given
+      const params = { request: {}, iss: 'did:pkh:eip155:1:0xabc' }
+      mockWalletKitInstance.formatAuthMessage.mockReturnValue('Sign this message')
+
+      // #when
+      const result = handler.formatAuthMessage(params)
+
+      // #then
+      expect(result).toBe('Sign this message')
+      expect(mockWalletKitInstance.formatAuthMessage).toHaveBeenCalledWith(params)
+    })
+  })
+
+  describe('pay', () => {
+    test('should return null before init', () => {
+      expect(handler.pay).toBeNull()
+    })
+
+    test('should return the pay client after init', async () => {
+      // #given
+      await handler.init(CONFIG)
+
+      // #then
+      expect(handler.pay).toBe(mockWalletKitInstance.pay)
+    })
+  })
+
+  describe('event forwarding', () => {
+    test('should forward walletkit events to the emitter', async () => {
+      // #given
+      await handler.init(CONFIG)
+
+      const events = ['session_proposal', 'session_request', 'session_delete',
+        'session_authenticate', 'proposal_expire', 'session_request_expire']
+
+      for (const event of events) {
+        const listener = jest.fn()
+        emitter.on(event, listener)
+
+        const onCall = mockWalletKitInstance.on.mock.calls.find(c => c[0] === event)
+        const payload = { id: 1, topic: 'test' }
+
+        // #when
+        onCall[1](payload)
+
+        // #then
+        expect(listener).toHaveBeenCalledWith(payload)
+
+        emitter.removeListener(event, listener)
+      }
+    })
+  })
+
+  describe('dispose', () => {
+    test('should clear walletkit reference', async () => {
+      // #given
+      await handler.init(CONFIG)
+
+      // #when
+      handler.dispose()
+
+      // #then
+      expect(handler.pay).toBeNull()
+    })
+
+    test('should be a no-op when not initialized', () => {
+      handler.dispose()
+    })
+  })
+})

--- a/tests/wdk-manager.test.js
+++ b/tests/wdk-manager.test.js
@@ -6,7 +6,32 @@ import WalletManager from '@tetherto/wdk-wallet'
 
 import { BridgeProtocol, LendingProtocol, SwapProtocol } from '@tetherto/wdk-wallet/protocols'
 
-import WdkManager from '../index.js'
+const mockWcHandler = {
+  init: jest.fn(),
+  pair: jest.fn(),
+  approveSession: jest.fn(),
+  rejectSession: jest.fn(),
+  respondRequest: jest.fn(),
+  rejectRequest: jest.fn(),
+  getSessions: jest.fn(),
+  getPendingSessionProposals: jest.fn(),
+  getPendingSessionRequests: jest.fn(),
+  disconnectSession: jest.fn(),
+  updateSession: jest.fn(),
+  extendSession: jest.fn(),
+  emitSessionEvent: jest.fn(),
+  approveSessionAuthenticate: jest.fn(),
+  rejectSessionAuthenticate: jest.fn(),
+  formatAuthMessage: jest.fn(),
+  dispose: jest.fn(),
+  pay: null
+}
+
+jest.unstable_mockModule('../src/walletconnect-handler.js', () => ({
+  default: jest.fn().mockImplementation(() => mockWcHandler)
+}))
+
+const { default: WdkManager } = await import('../index.js')
 
 const SEED_PHRASE = 'cook voyage document eight skate token alien guide drink uncle term abuse'
 
@@ -429,6 +454,7 @@ describe('WdkManager', () => {
   describe('dispose', () => {
     beforeEach(() => {
       disposeMock.mockClear()
+      mockWcHandler.dispose.mockClear()
     })
 
     test('should dispose all wallets when called without arguments', () => {
@@ -438,6 +464,7 @@ describe('WdkManager', () => {
       wdkManager.dispose()
 
       expect(disposeMock).toHaveBeenCalledTimes(2)
+      expect(mockWcHandler.dispose).toHaveBeenCalled()
     })
 
     test('should dispose only the specified wallets', () => {
@@ -476,6 +503,94 @@ describe('WdkManager', () => {
       wdkManager.dispose([])
 
       expect(disposeMock).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('WalletConnect', () => {
+    const WC_CONFIG = {
+      projectId: 'test-project-id',
+      metadata: { name: 'Test', description: 'Test', url: 'https://test.com', icons: [] }
+    }
+
+    beforeEach(() => {
+      jest.clearAllMocks()
+    })
+
+    test('initWalletConnect should delegate to handler and return wdk instance', async () => {
+      const result = await wdkManager.initWalletConnect(WC_CONFIG)
+
+      expect(mockWcHandler.init).toHaveBeenCalledWith(WC_CONFIG)
+      expect(result).toBe(wdkManager)
+    })
+
+    test('walletkit getter should delegate to handler', () => {
+      mockWcHandler.walletkit = { mock: true }
+      expect(wdkManager.walletkit).toEqual({ mock: true })
+    })
+
+    test('pair should delegate to handler', async () => {
+      await wdkManager.pair('wc:test-uri')
+
+      expect(mockWcHandler.pair).toHaveBeenCalledWith('wc:test-uri')
+    })
+
+    test('approveSession should delegate to handler', async () => {
+      const params = { id: 1, namespaces: {} }
+
+      await wdkManager.approveSession(params)
+
+      expect(mockWcHandler.approveSession).toHaveBeenCalledWith(params)
+    })
+
+    test('rejectSession should delegate to handler', async () => {
+      await wdkManager.rejectSession(1)
+
+      expect(mockWcHandler.rejectSession).toHaveBeenCalledWith(1)
+    })
+
+    test('respondRequest should delegate to handler', async () => {
+      await wdkManager.respondRequest(1, 'topic', { result: '0xsig' })
+
+      expect(mockWcHandler.respondRequest).toHaveBeenCalledWith(1, 'topic', { result: '0xsig' })
+    })
+
+    test('rejectRequest should delegate to handler', async () => {
+      await wdkManager.rejectRequest(1, 'topic', 'error')
+
+      expect(mockWcHandler.rejectRequest).toHaveBeenCalledWith(1, 'topic', 'error')
+    })
+
+    test('getSessions should delegate to handler', () => {
+      const sessions = { 'topic-1': {} }
+      mockWcHandler.getSessions.mockReturnValue(sessions)
+
+      expect(wdkManager.getSessions()).toBe(sessions)
+    })
+
+    test('disconnectSession should delegate to handler', async () => {
+      await wdkManager.disconnectSession('topic-1')
+
+      expect(mockWcHandler.disconnectSession).toHaveBeenCalledWith('topic-1')
+    })
+
+    test('updateSession should delegate to handler', async () => {
+      const params = { topic: 'topic-1', namespaces: {} }
+
+      await wdkManager.updateSession(params)
+
+      expect(mockWcHandler.updateSession).toHaveBeenCalledWith(params)
+    })
+
+    test('emitSessionEvent should delegate to handler', async () => {
+      const params = { topic: 'topic-1', event: {}, chainId: 'eip155:1' }
+
+      await wdkManager.emitSessionEvent(params)
+
+      expect(mockWcHandler.emitSessionEvent).toHaveBeenCalledWith(params)
+    })
+
+    test('pay should return handler pay client', () => {
+      expect(wdkManager.pay).toBe(mockWcHandler.pay)
     })
   })
 })

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -2,4 +2,5 @@ export { default } from "./src/wdk-manager.js";
 export type IWalletAccount = import("./src/wdk-manager.js").IWalletAccount;
 export type FeeRates = import("./src/wdk-manager.js").FeeRates;
 export type MiddlewareFunction = import("./src/wdk-manager.js").MiddlewareFunction;
+export type WalletConnectConfig = import("./src/wdk-manager.js").WalletConnectConfig;
 export type IWalletAccountWithProtocols = import("./src/wallet-account-with-protocols.js").IWalletAccountWithProtocols;

--- a/types/src/wallet-account-with-protocols.d.ts
+++ b/types/src/wallet-account-with-protocols.d.ts
@@ -1,5 +1,9 @@
+/** @typedef {import('@tetherto/wdk-wallet/protocols').ISwapProtocol} ISwapProtocol */
+/** @typedef {import('@tetherto/wdk-wallet/protocols').IBridgeProtocol} IBridgeProtocol */
+/** @typedef {import('@tetherto/wdk-wallet/protocols').ILendingProtocol} ILendingProtocol */
+/** @typedef {import('@tetherto/wdk-wallet/protocols').IFiatProtocol} IFiatProtocol */
 /** @interface */
-export interface IWalletAccountWithProtocols extends IWalletAccount {
+export class IWalletAccountWithProtocols {
     /**
      * Registers a new protocol for this account
      *
@@ -50,5 +54,3 @@ export type ISwapProtocol = import("@tetherto/wdk-wallet/protocols").ISwapProtoc
 export type IBridgeProtocol = import("@tetherto/wdk-wallet/protocols").IBridgeProtocol;
 export type ILendingProtocol = import("@tetherto/wdk-wallet/protocols").ILendingProtocol;
 export type IFiatProtocol = import("@tetherto/wdk-wallet/protocols").IFiatProtocol;
-import { IWalletAccount } from "@tetherto/wdk-wallet";
-import { SwapProtocol, BridgeProtocol, LendingProtocol, FiatProtocol } from "@tetherto/wdk-wallet/protocols";

--- a/types/src/walletconnect-handler.d.ts
+++ b/types/src/walletconnect-handler.d.ts
@@ -6,7 +6,7 @@
  * @property {string} projectId
  * @property {{ name: string, description: string, url: string, icons: string[] }} metadata
  * @property {string} [relayUrl]
- * @property {{ appId: string, apiKey: string, baseUrl?: string }} [payConfig]
+ * @property {{ appId: string, apiKey?: string, baseUrl?: string }} [payConfig]
  * @property {object} [signConfig]
  */
 /**
@@ -29,7 +29,7 @@ export default class WalletConnectHandler {
     /**
      * @returns {import('@reown/walletkit').WalletKit | null}
      */
-    get walletkit(): import("@reown/walletkit").WalletKit | null;
+    get walletkit(): import("@reown/walletkit").default | null;
     /**
      * @returns {import('@reown/walletkit').IWalletKitPay | null}
      */
@@ -163,7 +163,7 @@ export type WalletConnectConfig = {
     relayUrl?: string;
     payConfig?: {
         appId: string;
-        apiKey: string;
+        apiKey?: string;
         baseUrl?: string;
     };
     signConfig?: object;

--- a/types/src/walletconnect-handler.d.ts
+++ b/types/src/walletconnect-handler.d.ts
@@ -1,0 +1,170 @@
+/**
+ * @typedef {import('events').EventEmitter} EventEmitter
+ */
+/**
+ * @typedef {object} WalletConnectConfig
+ * @property {string} projectId
+ * @property {{ name: string, description: string, url: string, icons: string[] }} metadata
+ * @property {string} [relayUrl]
+ * @property {{ appId: string, apiKey: string, baseUrl?: string }} [payConfig]
+ * @property {object} [signConfig]
+ */
+/**
+ * Thin wrapper around WalletKit that forwards events to an external EventEmitter
+ * and exposes passthrough methods. No internal signing or request processing.
+ */
+export default class WalletConnectHandler {
+    /**
+     * @param {EventEmitter} emitter
+     */
+    constructor(emitter: EventEmitter);
+    /** @private */
+    private _emitter;
+    /** @private */
+    private _walletkit;
+    /**
+     * @param {WalletConnectConfig} config
+     */
+    init(config: WalletConnectConfig): Promise<void>;
+    /**
+     * @returns {import('@reown/walletkit').WalletKit | null}
+     */
+    get walletkit(): import("@reown/walletkit").WalletKit | null;
+    /**
+     * @returns {import('@reown/walletkit').IWalletKitPay | null}
+     */
+    get pay(): import("@reown/walletkit").IWalletKitPay | null;
+    /**
+     * @param {string} uri
+     */
+    pair(uri: string): Promise<void>;
+    /**
+     * Passthrough to walletkit.approveSession.
+     *
+     * @param {object} params
+     * @param {number} params.id
+     * @param {Record<string, object>} params.namespaces
+     * @param {object} [params.sessionProperties]
+     * @param {object} [params.scopedProperties]
+     * @param {object} [params.sessionConfig]
+     * @param {string} [params.relayProtocol]
+     * @param {object} [params.proposalRequestsResponses]
+     * @returns {Promise<object>}
+     */
+    approveSession(params: {
+        id: number;
+        namespaces: Record<string, object>;
+        sessionProperties?: object;
+        scopedProperties?: object;
+        sessionConfig?: object;
+        relayProtocol?: string;
+        proposalRequestsResponses?: object;
+    }): Promise<object>;
+    /**
+     * @param {number} id
+     */
+    rejectSession(id: number): Promise<void>;
+    /**
+     * @param {number} id
+     * @param {string} topic
+     * @param {object} params
+     * @param {*} params.result
+     */
+    respondRequest(id: number, topic: string, { result }: {
+        result: any;
+    }): Promise<void>;
+    /**
+     * @param {number} id
+     * @param {string} topic
+     * @param {string} [message]
+     */
+    rejectRequest(id: number, topic: string, message?: string): Promise<void>;
+    /**
+     * @returns {Record<string, object>}
+     */
+    getSessions(): Record<string, object>;
+    /**
+     * @returns {Record<number, object>}
+     */
+    getPendingSessionProposals(): Record<number, object>;
+    /**
+     * @returns {object[]}
+     */
+    getPendingSessionRequests(): object[];
+    /**
+     * @param {string} topic
+     */
+    disconnectSession(topic: string): Promise<void>;
+    /**
+     * @param {object} params
+     * @param {string} params.topic
+     * @param {Record<string, object>} params.namespaces
+     */
+    updateSession(params: {
+        topic: string;
+        namespaces: Record<string, object>;
+    }): Promise<{
+        acknowledged: () => Promise<void>;
+    }>;
+    /**
+     * @param {object} params
+     * @param {string} params.topic
+     */
+    extendSession(params: {
+        topic: string;
+    }): Promise<{
+        acknowledged: () => Promise<void>;
+    }>;
+    /**
+     * @param {object} params
+     * @param {string} params.topic
+     * @param {*} params.event
+     * @param {string} params.chainId
+     */
+    emitSessionEvent(params: {
+        topic: string;
+        event: any;
+        chainId: string;
+    }): Promise<void>;
+    /**
+     * @param {object} params
+     */
+    approveSessionAuthenticate(params: object): Promise<{
+        session: import("@walletconnect/types").SessionTypes.Struct | undefined;
+    }>;
+    /**
+     * @param {object} params
+     * @param {number} params.id
+     */
+    rejectSessionAuthenticate(params: {
+        id: number;
+    }): Promise<void>;
+    /**
+     * @param {object} params
+     * @param {{ request: object, iss: string }} params
+     * @returns {string}
+     */
+    formatAuthMessage(params: object): string;
+    dispose(): void;
+    /** @private */
+    private _ensureInitialized;
+    /** @private */
+    private _subscribeToEvents;
+}
+export type EventEmitter = import("events").EventEmitter;
+export type WalletConnectConfig = {
+    projectId: string;
+    metadata: {
+        name: string;
+        description: string;
+        url: string;
+        icons: string[];
+    };
+    relayUrl?: string;
+    payConfig?: {
+        appId: string;
+        apiKey: string;
+        baseUrl?: string;
+    };
+    signConfig?: object;
+};

--- a/types/src/wdk-manager.d.ts
+++ b/types/src/wdk-manager.d.ts
@@ -1,4 +1,9 @@
-export default class WdkManager {
+/** @typedef {import('@tetherto/wdk-wallet').IWalletAccount} IWalletAccount */
+/** @typedef {import('@tetherto/wdk-wallet').FeeRates} FeeRates */
+/** @typedef {import('./wallet-account-with-protocols.js').IWalletAccountWithProtocols} IWalletAccountWithProtocols */
+/** @typedef {import('./walletconnect-handler.js').WalletConnectConfig} WalletConnectConfig */
+/** @typedef {<A extends IWalletAccount>(account: A) => Promise<void>} MiddlewareFunction */
+export default class WDK extends EventEmitter<any> {
     /**
      * Returns a random BIP-39 seed phrase.
      *
@@ -13,7 +18,7 @@ export default class WdkManager {
      */
     static isValidSeed(seed: string | Uint8Array): boolean;
     /**
-     * Creates a new wallet development kit manager.
+     * Creates a new wallet development kit instance.
      *
      * @param {string | Uint8Array} seed - The wallet's BIP-39 seed phrase.
      * @throws {Error} If the seed is not valid.
@@ -27,18 +32,20 @@ export default class WdkManager {
     private _protocols;
     /** @private */
     private _middlewares;
+    /** @private */
+    private _wc;
     /**
-     * Registers a new wallet to the wdk manager.
+     * Registers a new wallet to WDK.
      *
      * @template {typeof WalletManager} W
      * @param {string} blockchain - The name of the blockchain the wallet must be bound to. Can be any string (e.g., "ethereum").
      * @param {W} WalletManager - The wallet manager class.
      * @param {ConstructorParameters<W>[1]} config - The configuration object.
-     * @returns {WdkManager} The wdk manager.
+     * @returns {WDK} The wdk instance.
      */
-    registerWallet<W extends typeof WalletManager>(blockchain: string, WalletManager: W, config: ConstructorParameters<W>[1]): WdkManager;
+    registerWallet<W extends typeof import("@tetherto/wdk-wallet").default>(blockchain: string, WalletManager: W, config: ConstructorParameters<W>[1]): WDK;
     /**
-     * Registers a new protocol to the wdk manager.
+     * Registers a new protocol to WDK.
      *
      * The label must be unique in the scope of the blockchain and the type of protocol (i.e., there can't be two protocols of the
      * same type bound to the same blockchain with the same label).
@@ -49,19 +56,19 @@ export default class WdkManager {
      * @param {string} label - The label.
      * @param {P} Protocol - The protocol class.
      * @param {ConstructorParameters<P>[1]} config - The protocol configuration.
-     * @returns {WdkManager} The wdk manager.
+     * @returns {WDK} The wdk instance.
      */
     registerProtocol<P extends typeof SwapProtocol | typeof BridgeProtocol | typeof LendingProtocol | typeof FiatProtocol>(blockchain: string, label: string, Protocol: P, config: ConstructorParameters<P>[1]): WDK;
     /**
-     * Registers a new middleware to the wdk manager.
+     * Registers a new middleware to WDK.
      *
      * It's possible to register multiple middlewares for the same blockchain, which will be called sequentially.
      *
      * @param {string} blockchain - The name of the blockchain the middleware must be bound to. Can be any string (e.g., "ethereum").
      * @param {MiddlewareFunction} middleware - A callback function that is called each time the user derives a new account.
-     * @returns {WdkManager} The wdk manager.
+     * @returns {WDK} The wdk instance.
      */
-    registerMiddleware(blockchain: string, middleware: MiddlewareFunction): WdkManager;
+    registerMiddleware(blockchain: string, middleware: MiddlewareFunction): WDK;
     /**
      * Returns the wallet account for a specific blockchain and index (see BIP-44).
      *
@@ -89,10 +96,187 @@ export default class WdkManager {
      */
     getFeeRates(blockchain: string): Promise<FeeRates>;
     /**
-    * Disposes and unregisters wallets, erasing any sensitive data from memory.
-    * If no blockchains are specified, all registered wallets are disposed.
-    * @param {string[]} [blockchains] - The blockchains to dispose. If omitted, all wallets are disposed.
-    */
+     * Initializes WalletConnect (WalletKit) and subscribes to session events.
+     * Events are emitted on this WDK instance: session_proposal, session_request,
+     * session_delete, session_authenticate, proposal_expire, session_request_expire, payment_link.
+     *
+     * @param {WalletConnectConfig} config
+     * @returns {Promise<WDK>}
+     */
+    initWalletConnect(config: WalletConnectConfig): Promise<WDK>;
+    /**
+     * The underlying WalletKit instance. Available after initWalletConnect.
+     *
+     * @returns {import('@reown/walletkit').WalletKit | null}
+     */
+    get walletkit(): import("@reown/walletkit").WalletKit | null;
+    /**
+     * The WalletConnect Pay client. Available after initWalletConnect with payConfig.
+     *
+     * @returns {import('@reown/walletkit').IWalletKitPay | null}
+     */
+    get pay(): import("@reown/walletkit").IWalletKitPay | null;
+    /**
+     * Pairs with a dApp via URI or detects a payment link.
+     * Payment links emit a 'payment_link' event instead of pairing.
+     *
+     * @param {string} uri
+     * @returns {Promise<void>}
+     */
+    pair(uri: string): Promise<void>;
+    /**
+     * Approves a session proposal. Passthrough to WalletKit — all params are forwarded as-is.
+     *
+     * @param {object} params
+     * @param {number} params.id
+     * @param {Record<string, object>} params.namespaces
+     * @param {object} [params.sessionProperties]
+     * @param {object} [params.scopedProperties]
+     * @param {object} [params.sessionConfig]
+     * @param {string} [params.relayProtocol]
+     * @param {object} [params.proposalRequestsResponses]
+     * @returns {Promise<object>} The session.
+     */
+    approveSession(params: {
+        id: number;
+        namespaces: Record<string, object>;
+        sessionProperties?: object;
+        scopedProperties?: object;
+        sessionConfig?: object;
+        relayProtocol?: string;
+        proposalRequestsResponses?: object;
+    }): Promise<object>;
+    /**
+     * Rejects a session proposal.
+     *
+     * @param {number} id
+     * @returns {Promise<void>}
+     */
+    rejectSession(id: number): Promise<void>;
+    /**
+     * Responds to a session request with a result provided by the consumer.
+     *
+     * @param {number} id
+     * @param {string} topic
+     * @param {object} params
+     * @param {*} params.result
+     * @returns {Promise<void>}
+     */
+    respondRequest(id: number, topic: string, { result }: {
+        result: any;
+    }): Promise<void>;
+    /**
+     * Rejects a session request.
+     *
+     * @param {number} id
+     * @param {string} topic
+     * @param {string} [message]
+     * @returns {Promise<void>}
+     */
+    rejectRequest(id: number, topic: string, message?: string): Promise<void>;
+    /**
+     * Returns all active WalletConnect sessions.
+     *
+     * @returns {Record<string, object>}
+     */
+    getSessions(): Record<string, object>;
+    /**
+     * Returns all pending session proposals.
+     *
+     * @returns {Record<number, object>}
+     */
+    getPendingSessionProposals(): Record<number, object>;
+    /**
+     * Returns all pending session requests.
+     *
+     * @returns {object[]}
+     */
+    getPendingSessionRequests(): object[];
+    /**
+     * Disconnects a WalletConnect session.
+     *
+     * @param {string} topic
+     * @returns {Promise<void>}
+     */
+    disconnectSession(topic: string): Promise<void>;
+    /**
+     * Updates a session's namespaces.
+     *
+     * @param {object} params
+     * @param {string} params.topic
+     * @param {Record<string, object>} params.namespaces
+     * @returns {Promise<{ acknowledged: () => Promise<void> }>}
+     */
+    updateSession(params: {
+        topic: string;
+        namespaces: Record<string, object>;
+    }): Promise<{
+        acknowledged: () => Promise<void>;
+    }>;
+    /**
+     * Extends a session's expiry.
+     *
+     * @param {object} params
+     * @param {string} params.topic
+     * @returns {Promise<{ acknowledged: () => Promise<void> }>}
+     */
+    extendSession(params: {
+        topic: string;
+    }): Promise<{
+        acknowledged: () => Promise<void>;
+    }>;
+    /**
+     * Emits an event to a connected dApp.
+     *
+     * @param {object} params
+     * @param {string} params.topic
+     * @param {*} params.event
+     * @param {string} params.chainId
+     * @returns {Promise<void>}
+     */
+    emitSessionEvent(params: {
+        topic: string;
+        event: any;
+        chainId: string;
+    }): Promise<void>;
+    /**
+     * Approves a standalone session authentication request.
+     *
+     * @param {object} params
+     * @returns {Promise<{ session: object | undefined }>}
+     */
+    approveSessionAuthenticate(params: object): Promise<{
+        session: object | undefined;
+    }>;
+    /**
+     * Rejects a standalone session authentication request.
+     *
+     * @param {object} params
+     * @param {number} params.id
+     * @returns {Promise<void>}
+     */
+    rejectSessionAuthenticate(params: {
+        id: number;
+    }): Promise<void>;
+    /**
+     * Formats an authentication message for signing.
+     *
+     * @param {object} params
+     * @param {object} params.request
+     * @param {string} params.iss
+     * @returns {string}
+     */
+    formatAuthMessage(params: {
+        request: object;
+        iss: string;
+    }): string;
+    /**
+     * Disposes and unregisters wallets, erasing any sensitive data from memory.
+     * If no blockchains are specified, all registered wallets are disposed.
+     * WalletConnect sessions should be disconnected explicitly via disconnectSession() before calling dispose.
+     *
+     * @param {string[]} [blockchains] - The blockchains to dispose. If omitted, all wallets are disposed.
+     */
     dispose(blockchains?: string[]): void;
     /** @private */
     private _runMiddlewares;
@@ -102,9 +286,10 @@ export default class WdkManager {
 export type IWalletAccount = import("@tetherto/wdk-wallet").IWalletAccount;
 export type FeeRates = import("@tetherto/wdk-wallet").FeeRates;
 export type IWalletAccountWithProtocols = import("./wallet-account-with-protocols.js").IWalletAccountWithProtocols;
+export type WalletConnectConfig = import("./walletconnect-handler.js").WalletConnectConfig;
 export type MiddlewareFunction = <A extends IWalletAccount>(account: A) => Promise<void>;
-import WalletManager from "@tetherto/wdk-wallet";
-import { SwapProtocol } from "@tetherto/wdk-wallet/protocols";
-import { BridgeProtocol } from "@tetherto/wdk-wallet/protocols";
-import { LendingProtocol } from "@tetherto/wdk-wallet/protocols";
-import { FiatProtocol } from "@tetherto/wdk-wallet/protocols";
+import { EventEmitter } from 'events';
+import { SwapProtocol } from '@tetherto/wdk-wallet/protocols';
+import { BridgeProtocol } from '@tetherto/wdk-wallet/protocols';
+import { LendingProtocol } from '@tetherto/wdk-wallet/protocols';
+import { FiatProtocol } from '@tetherto/wdk-wallet/protocols';

--- a/types/src/wdk-manager.d.ts
+++ b/types/src/wdk-manager.d.ts
@@ -109,7 +109,7 @@ export default class WDK extends EventEmitter<any> {
      *
      * @returns {import('@reown/walletkit').WalletKit | null}
      */
-    get walletkit(): import("@reown/walletkit").WalletKit | null;
+    get walletkit(): import("@reown/walletkit").default | null;
     /**
      * The WalletConnect Pay client. Available after initWalletConnect with payConfig.
      *


### PR DESCRIPTION
## Summary

Integrates WalletConnect v2 (WalletKit) into WDK as a headless handler, enabling session management (Sign) and WalletConnect Pay support out of the box.

**Architecture:**

- WDK extends `EventEmitter` and emits all WalletConnect lifecycle events (`session_proposal`, `session_request`, `session_delete`, etc.) for the consuming application to handle UI and signing
- New `WalletConnectHandler` class acts as a thin wrapper around `@reown/walletkit`, forwarding events and exposing passthrough methods
- No internal signing — WDK exposes payloads and the consumer provides signed results via `respondRequest()`

**New capabilities:**

- `wdk.initWalletConnect(config)` — initializes WalletKit with project ID and metadata
- `wdk.walletkit` — direct access to the underlying WalletKit instance
- `wdk.pay` — access to WalletConnect Pay client
- Full session lifecycle: `pair`, `approveSession`, `rejectSession`, `respondRequest`, `rejectRequest`, `disconnectSession`
- Session management: `getSessions`, `updateSession`, `extendSession`, `emitSessionEvent`
- Authentication: `approveSessionAuthenticate`, `rejectSessionAuthenticate`, `formatAuthMessage`
- Payment link detection: `pair()` auto-detects WC Pay links and emits `payment_link` event

**Dependencies added:**

- `@reown/walletkit`, `@walletconnect/utils`, `@walletconnect/pay`, `@json-rpc-tools/utils`, `tslib` (runtime)
- `@walletconnect/sign-client`, `dotenv` (dev — for e2e tests)

**Tests:**

- Unit tests for `WalletConnectHandler` (all methods, event forwarding, error handling)
- Unit tests for `WDK` WalletConnect delegation methods
- E2E tests against the live WalletConnect relay (requires `WC_PROJECT_ID` env var):
  - Full session lifecycle: init → pair → approve → request → respond → disconnect
  - Session proposal rejection
  - Session request rejection

## Consumer usage

```js
const wdk = new WDK(seed)
  .registerWallet('ethereum', WalletManagerEvm, config)

await wdk.initWalletConnect({
  projectId: 'your-project-id',
  metadata: { name: 'My Wallet', description: '...', url: '...', icons: ['...'] }
})

// Listen for session proposals
wdk.on('session_proposal', async (proposal) => {
  // Show UI to user, then approve or reject
  await wdk.approveSession({
    id: proposal.id,
    namespaces: { eip155: { accounts: [...], methods: [...], events: [...] } }
  })
})

// Listen for signing requests
wdk.on('session_request', async (request) => {
  // Sign the payload externally
  const signature = await mySigningFunction(request.params.request)
  await wdk.respondRequest(request.id, request.topic, { result: signature })
})

// WalletConnect Pay — detect payment links via pair()
wdk.on('payment_link', async ({ uri }) => {
  const accounts = ['eip155:1:0xYourAddress']

  // 1. Get payment options for the link
  const { paymentId, info, options } = await wdk.pay.getPaymentOptions({
    paymentLink: uri,
    accounts,
  })

  // 2. Show options to user, they pick one
  const chosen = options[0]

  // 3. Get the required signing actions
  const actions = await wdk.pay.getRequiredPaymentActions({
    paymentId,
    optionId: chosen.id
  })

  // 4. Sign each action's wallet RPC call externally
  const signatures = []
  for (const action of actions) {
    const { chainId, method, params } = action.walletRpc
    const sig = await mySignFunction(chainId, method, JSON.parse(params))
    signatures.push(sig)
  }

  // 5. Confirm payment with signatures
  const result = await wdk.pay.confirmPayment({
    paymentId,
    optionId: chosen.id,
    signatures
  })
})
```

## Test plan

- [x] Unit tests pass: `npm test`
- [x] E2E tests pass: `WC_PROJECT_ID=<id> npm test -- tests/walletconnect-e2e.test.js --forceExit`
- [x] Verify no regressions in existing wallet/protocol tests
- [x] Verify types build: `npm run build:types`
