### PR TITLE
Tracer hook for orchestrator observability

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,7 +17,10 @@
 /** @typedef {import('./src/wdk-manager.js').IWalletAccount} IWalletAccount */
 /** @typedef {import('./src/wdk-manager.js').FeeRates} FeeRates */
 /** @typedef {import('./src/wdk-manager.js').MiddlewareFunction} MiddlewareFunction */
+/** @typedef {import('./src/wdk-manager.js').TraceEvent} TraceEvent */
+/** @typedef {import('./src/wdk-manager.js').TracerFn} TracerFn */
+/** @typedef {import('./src/wdk-manager.js').WDKConfig} WDKConfig */
 
 /** @typedef {import('./src/wallet-account-with-protocols.js').IWalletAccountWithProtocols} IWalletAccountWithProtocols */
 
-export { default } from './src/wdk-manager.js'
+export { default, TraceEvents } from './src/wdk-manager.js'

--- a/src/wdk-manager.js
+++ b/src/wdk-manager.js
@@ -26,14 +26,53 @@ import { SwapProtocol, BridgeProtocol, LendingProtocol, FiatProtocol } from '@te
 
 /** @typedef {<A extends IWalletAccount>(account: A) => Promise<void>} MiddlewareFunction */
 
+/**
+ * @typedef {Object} TraceEvent
+ * @property {string} name - The event name (e.g. "wdk.account.resolved").
+ * @property {number} startedAt - Epoch milliseconds when the operation started.
+ * @property {number} [durationMs] - Elapsed time in milliseconds (omitted for fire-and-forget events).
+ * @property {Error} [error] - The error thrown by the operation, if any.
+ * @property {string} [blockchain] - The blockchain the event relates to, if any.
+ * @property {Record<string, unknown>} [meta] - Additional event-specific metadata.
+ */
+
+/** @typedef {(event: TraceEvent) => void} TracerFn */
+
+/**
+ * @typedef {Object} WDKConfig
+ * @property {TracerFn} [tracer] - Optional observability hook. Called synchronously for every orchestrator operation with a structured event. Defaults to a no-op.
+ */
+
+/**
+ * Canonical event names emitted by the WDK orchestrator. Use this enum instead
+ * of magic strings when filtering or routing in a {@link TracerFn}.
+ */
+export const TraceEvents = Object.freeze({
+  Created: 'wdk.created',
+  WalletRegistered: 'wdk.wallet.registered',
+  WalletRegisterFailed: 'wdk.wallet.register_failed',
+  ProtocolRegistered: 'wdk.protocol.registered',
+  MiddlewareRegistered: 'wdk.middleware.registered',
+  MiddlewareExecuted: 'wdk.middleware.executed',
+  MiddlewareFailed: 'wdk.middleware.failed',
+  AccountResolved: 'wdk.account.resolved',
+  AccountFailed: 'wdk.account.failed',
+  FeeRatesResolved: 'wdk.fee_rates.resolved',
+  FeeRatesFailed: 'wdk.fee_rates.failed',
+  Disposed: 'wdk.disposed'
+})
+
+const NOOP_TRACER = () => {}
+
 export default class WDK {
   /**
    * Creates a new wallet development kit instance.
    *
    * @param {string | Uint8Array} seed - The wallet's BIP-39 seed phrase.
+   * @param {WDKConfig} [config] - Optional WDK configuration.
    * @throws {Error} If the seed is not valid.
    */
-  constructor (seed) {
+  constructor (seed, config = {}) {
     if (!WDK.isValidSeed(seed)) {
       throw new Error('Invalid seed.')
     }
@@ -49,6 +88,11 @@ export default class WDK {
 
     /** @private */
     this._middlewares = Object.create(null)
+
+    /** @private */
+    this._tracer = typeof config.tracer === 'function' ? config.tracer : NOOP_TRACER
+
+    this._trace(TraceEvents.Created, { startedAt: Date.now() })
   }
 
   /**
@@ -85,9 +129,18 @@ export default class WDK {
    * @returns {WDK} The wdk instance.
    */
   registerWallet (blockchain, WalletManager, config) {
-    const wallet = new WalletManager(this._seed, config)
+    const startedAt = Date.now()
 
-    this._wallets.set(blockchain, wallet)
+    try {
+      const wallet = new WalletManager(this._seed, config)
+
+      this._wallets.set(blockchain, wallet)
+    } catch (error) {
+      this._trace(TraceEvents.WalletRegisterFailed, { startedAt, durationMs: Date.now() - startedAt, blockchain, error })
+      throw error
+    }
+
+    this._trace(TraceEvents.WalletRegistered, { startedAt, durationMs: Date.now() - startedAt, blockchain })
 
     return this
   }
@@ -107,23 +160,32 @@ export default class WDK {
    * @returns {WDK} The wdk instance.
    */
   registerProtocol (blockchain, label, Protocol, config) {
+    const startedAt = Date.now()
+    let kind
+
     if (Protocol.prototype instanceof SwapProtocol) {
       this._protocols.swap[blockchain] ??= Object.create(null)
 
       this._protocols.swap[blockchain][label] = { Protocol, config }
+      kind = 'swap'
     } else if (Protocol.prototype instanceof BridgeProtocol) {
       this._protocols.bridge[blockchain] ??= Object.create(null)
 
       this._protocols.bridge[blockchain][label] = { Protocol, config }
+      kind = 'bridge'
     } else if (Protocol.prototype instanceof LendingProtocol) {
       this._protocols.lending[blockchain] ??= Object.create(null)
 
       this._protocols.lending[blockchain][label] = { Protocol, config }
+      kind = 'lending'
     } else if (Protocol.prototype instanceof FiatProtocol) {
       this._protocols.fiat[blockchain] ??= Object.create(null)
 
       this._protocols.fiat[blockchain][label] = { Protocol, config }
+      kind = 'fiat'
     }
+
+    this._trace(TraceEvents.ProtocolRegistered, { startedAt, durationMs: Date.now() - startedAt, blockchain, meta: { kind, label } })
 
     return this
   }
@@ -142,6 +204,8 @@ export default class WDK {
 
     this._middlewares[blockchain].push(middleware)
 
+    this._trace(TraceEvents.MiddlewareRegistered, { startedAt: Date.now(), blockchain })
+
     return this
   }
 
@@ -154,19 +218,28 @@ export default class WDK {
    * @throws {Error} If no wallet has been registered for the given blockchain.
    */
   async getAccount (blockchain, index = 0) {
-    if (!this._wallets.has(blockchain)) {
-      throw new Error(`No wallet registered for blockchain: ${blockchain}.`)
+    const startedAt = Date.now()
+
+    try {
+      if (!this._wallets.has(blockchain)) {
+        throw new Error(`No wallet registered for blockchain: ${blockchain}.`)
+      }
+
+      const wallet = this._wallets.get(blockchain)
+
+      const account = await wallet.getAccount(index)
+
+      await this._runMiddlewares(account, { blockchain })
+
+      this._registerProtocols(account, { blockchain })
+
+      this._trace(TraceEvents.AccountResolved, { startedAt, durationMs: Date.now() - startedAt, blockchain, meta: { index } })
+
+      return account
+    } catch (error) {
+      this._trace(TraceEvents.AccountFailed, { startedAt, durationMs: Date.now() - startedAt, blockchain, error, meta: { index } })
+      throw error
     }
-
-    const wallet = this._wallets.get(blockchain)
-
-    const account = await wallet.getAccount(index)
-
-    await this._runMiddlewares(account, { blockchain })
-
-    this._registerProtocols(account, { blockchain })
-
-    return account
   }
 
   /**
@@ -178,19 +251,28 @@ export default class WDK {
    * @throws {Error} If no wallet has been registered for the given blockchain.
    */
   async getAccountByPath (blockchain, path) {
-    if (!this._wallets.has(blockchain)) {
-      throw new Error(`No wallet registered for blockchain: ${blockchain}.`)
+    const startedAt = Date.now()
+
+    try {
+      if (!this._wallets.has(blockchain)) {
+        throw new Error(`No wallet registered for blockchain: ${blockchain}.`)
+      }
+
+      const wallet = this._wallets.get(blockchain)
+
+      const account = await wallet.getAccountByPath(path)
+
+      await this._runMiddlewares(account, { blockchain })
+
+      this._registerProtocols(account, { blockchain })
+
+      this._trace(TraceEvents.AccountResolved, { startedAt, durationMs: Date.now() - startedAt, blockchain, meta: { path } })
+
+      return account
+    } catch (error) {
+      this._trace(TraceEvents.AccountFailed, { startedAt, durationMs: Date.now() - startedAt, blockchain, error, meta: { path } })
+      throw error
     }
-
-    const wallet = this._wallets.get(blockchain)
-
-    const account = await wallet.getAccountByPath(path)
-
-    await this._runMiddlewares(account, { blockchain })
-
-    this._registerProtocols(account, { blockchain })
-
-    return account
   }
 
   /**
@@ -201,15 +283,24 @@ export default class WDK {
    * @throws {Error} If no wallet has been registered for the given blockchain.
    */
   async getFeeRates (blockchain) {
-    if (!this._wallets.has(blockchain)) {
-      throw new Error(`No wallet registered for blockchain: ${blockchain}.`)
+    const startedAt = Date.now()
+
+    try {
+      if (!this._wallets.has(blockchain)) {
+        throw new Error(`No wallet registered for blockchain: ${blockchain}.`)
+      }
+
+      const wallet = this._wallets.get(blockchain)
+
+      const feeRates = await wallet.getFeeRates()
+
+      this._trace(TraceEvents.FeeRatesResolved, { startedAt, durationMs: Date.now() - startedAt, blockchain })
+
+      return feeRates
+    } catch (error) {
+      this._trace(TraceEvents.FeeRatesFailed, { startedAt, durationMs: Date.now() - startedAt, blockchain, error })
+      throw error
     }
-
-    const wallet = this._wallets.get(blockchain)
-
-    const feeRates = await wallet.getFeeRates()
-
-    return feeRates
   }
 
   /**
@@ -218,20 +309,43 @@ export default class WDK {
    * @param {string[]} [blockchains] - The blockchains to dispose. If omitted, all wallets are disposed.
    */
   dispose (blockchains) {
+    const startedAt = Date.now()
+    const disposed = []
+
     for (const [blockchain, wallet] of this._wallets) {
       if (!blockchains || blockchains.includes(blockchain)) {
         wallet.dispose()
         this._wallets.delete(blockchain)
+        disposed.push(blockchain)
       }
     }
+
+    this._trace(TraceEvents.Disposed, { startedAt, durationMs: Date.now() - startedAt, meta: { disposed } })
   }
 
   /** @private */
   async _runMiddlewares (account, { blockchain }) {
     if (this._middlewares[blockchain]) {
       for (const middleware of this._middlewares[blockchain]) {
-        await middleware(account)
+        const startedAt = Date.now()
+
+        try {
+          await middleware(account)
+          this._trace(TraceEvents.MiddlewareExecuted, { startedAt, durationMs: Date.now() - startedAt, blockchain })
+        } catch (error) {
+          this._trace(TraceEvents.MiddlewareFailed, { startedAt, durationMs: Date.now() - startedAt, blockchain, error })
+          throw error
+        }
       }
+    }
+  }
+
+  /** @private */
+  _trace (name, payload) {
+    try {
+      this._tracer({ name, ...payload })
+    } catch {
+      // Tracer errors must never break the orchestrator.
     }
   }
 

--- a/tests/wdk-manager.test.js
+++ b/tests/wdk-manager.test.js
@@ -6,7 +6,7 @@ import WalletManager from '@tetherto/wdk-wallet'
 
 import { BridgeProtocol, LendingProtocol, SwapProtocol } from '@tetherto/wdk-wallet/protocols'
 
-import WdkManager from '../index.js'
+import WdkManager, { TraceEvents } from '../index.js'
 
 const SEED_PHRASE = 'cook voyage document eight skate token alien guide drink uncle term abuse'
 
@@ -476,6 +476,105 @@ describe('WdkManager', () => {
       wdkManager.dispose([])
 
       expect(disposeMock).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('tracer', () => {
+    test('should not be invoked when no tracer is configured', () => {
+      const wdk = new WdkManager(SEED_PHRASE)
+
+      wdk.registerWallet('ethereum', WalletManagerMock, CONFIG)
+      wdk.dispose()
+
+      expect(true).toBe(true)
+    })
+
+    test('should emit wdk.created on construction', () => {
+      const tracer = jest.fn()
+
+      new WdkManager(SEED_PHRASE, { tracer })
+
+      expect(tracer).toHaveBeenCalledWith(expect.objectContaining({ name: TraceEvents.Created }))
+    })
+
+    test('should emit wdk.wallet.registered with blockchain and duration', () => {
+      const tracer = jest.fn()
+      const wdk = new WdkManager(SEED_PHRASE, { tracer })
+
+      wdk.registerWallet('ethereum', WalletManagerMock, CONFIG)
+
+      const event = tracer.mock.calls.find(([e]) => e.name === TraceEvents.WalletRegistered)?.[0]
+      expect(event).toBeDefined()
+      expect(event.blockchain).toBe('ethereum')
+      expect(typeof event.startedAt).toBe('number')
+      expect(typeof event.durationMs).toBe('number')
+    })
+
+    test('should emit wdk.account.resolved on success', async () => {
+      getAccountMock.mockResolvedValue({ getAddress: async () => '0x0' })
+
+      const tracer = jest.fn()
+      const wdk = new WdkManager(SEED_PHRASE, { tracer })
+      wdk.registerWallet('ethereum', WalletManagerMock, CONFIG)
+
+      await wdk.getAccount('ethereum', 7)
+
+      const event = tracer.mock.calls.find(([e]) => e.name === TraceEvents.AccountResolved)?.[0]
+      expect(event).toBeDefined()
+      expect(event.blockchain).toBe('ethereum')
+      expect(event.meta).toEqual({ index: 7 })
+    })
+
+    test('should emit wdk.account.failed when no wallet is registered', async () => {
+      const tracer = jest.fn()
+      const wdk = new WdkManager(SEED_PHRASE, { tracer })
+
+      await expect(wdk.getAccount('ethereum', 0)).rejects.toThrow()
+
+      const event = tracer.mock.calls.find(([e]) => e.name === TraceEvents.AccountFailed)?.[0]
+      expect(event).toBeDefined()
+      expect(event.error).toBeInstanceOf(Error)
+    })
+
+    test('should emit wdk.middleware.executed for each middleware run', async () => {
+      getAccountMock.mockResolvedValue({ getAddress: async () => '0x0' })
+
+      const tracer = jest.fn()
+      const wdk = new WdkManager(SEED_PHRASE, { tracer })
+      wdk.registerWallet('ethereum', WalletManagerMock, CONFIG)
+                .registerMiddleware('ethereum', async () => {})
+                .registerMiddleware('ethereum', async () => {})
+
+      await wdk.getAccount('ethereum', 0)
+
+      const events = tracer.mock.calls.filter(([e]) => e.name === TraceEvents.MiddlewareExecuted)
+      expect(events).toHaveLength(2)
+    })
+
+    test('should emit wdk.middleware.failed and re-throw when a middleware rejects', async () => {
+      getAccountMock.mockResolvedValue({ getAddress: async () => '0x0' })
+
+      const tracer = jest.fn()
+      const wdk = new WdkManager(SEED_PHRASE, { tracer })
+      const boom = new Error('boom')
+      wdk.registerWallet('ethereum', WalletManagerMock, CONFIG)
+                .registerMiddleware('ethereum', async () => { throw boom })
+
+      await expect(wdk.getAccount('ethereum', 0)).rejects.toBe(boom)
+
+      const event = tracer.mock.calls.find(([e]) => e.name === TraceEvents.MiddlewareFailed)?.[0]
+      expect(event).toBeDefined()
+      expect(event.error).toBe(boom)
+    })
+
+    test('should not propagate errors thrown by the tracer itself', () => {
+      const tracer = jest.fn(() => { throw new Error('tracer exploded') })
+
+      expect(() => new WdkManager(SEED_PHRASE, { tracer })).not.toThrow()
+    })
+
+    test('should ignore non-function tracer values', () => {
+      expect(() => new WdkManager(SEED_PHRASE, { tracer: 'not a function' })).not.toThrow()
     })
   })
 })

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,5 +1,8 @@
-export { default } from "./src/wdk-manager.js";
 export type IWalletAccount = import("./src/wdk-manager.js").IWalletAccount;
 export type FeeRates = import("./src/wdk-manager.js").FeeRates;
 export type MiddlewareFunction = import("./src/wdk-manager.js").MiddlewareFunction;
+export type TraceEvent = import("./src/wdk-manager.js").TraceEvent;
+export type TracerFn = import("./src/wdk-manager.js").TracerFn;
+export type WDKConfig = import("./src/wdk-manager.js").WDKConfig;
 export type IWalletAccountWithProtocols = import("./src/wallet-account-with-protocols.js").IWalletAccountWithProtocols;
+export { default, TraceEvents } from "./src/wdk-manager.js";

--- a/types/src/wallet-account-with-protocols.d.ts
+++ b/types/src/wallet-account-with-protocols.d.ts
@@ -1,5 +1,9 @@
+/** @typedef {import('@tetherto/wdk-wallet/protocols').ISwapProtocol} ISwapProtocol */
+/** @typedef {import('@tetherto/wdk-wallet/protocols').IBridgeProtocol} IBridgeProtocol */
+/** @typedef {import('@tetherto/wdk-wallet/protocols').ILendingProtocol} ILendingProtocol */
+/** @typedef {import('@tetherto/wdk-wallet/protocols').IFiatProtocol} IFiatProtocol */
 /** @interface */
-export interface IWalletAccountWithProtocols extends IWalletAccount {
+export class IWalletAccountWithProtocols {
     /**
      * Registers a new protocol for this account
      *
@@ -50,5 +54,3 @@ export type ISwapProtocol = import("@tetherto/wdk-wallet/protocols").ISwapProtoc
 export type IBridgeProtocol = import("@tetherto/wdk-wallet/protocols").IBridgeProtocol;
 export type ILendingProtocol = import("@tetherto/wdk-wallet/protocols").ILendingProtocol;
 export type IFiatProtocol = import("@tetherto/wdk-wallet/protocols").IFiatProtocol;
-import { IWalletAccount } from "@tetherto/wdk-wallet";
-import { SwapProtocol, BridgeProtocol, LendingProtocol, FiatProtocol } from "@tetherto/wdk-wallet/protocols";

--- a/types/src/wdk-manager.d.ts
+++ b/types/src/wdk-manager.d.ts
@@ -1,4 +1,40 @@
-export default class WdkManager {
+/** @typedef {import('@tetherto/wdk-wallet').IWalletAccount} IWalletAccount */
+/** @typedef {import('@tetherto/wdk-wallet').FeeRates} FeeRates */
+/** @typedef {import('./wallet-account-with-protocols.js').IWalletAccountWithProtocols} IWalletAccountWithProtocols */
+/** @typedef {<A extends IWalletAccount>(account: A) => Promise<void>} MiddlewareFunction */
+/**
+ * @typedef {Object} TraceEvent
+ * @property {string} name - The event name (e.g. "wdk.account.resolved").
+ * @property {number} startedAt - Epoch milliseconds when the operation started.
+ * @property {number} [durationMs] - Elapsed time in milliseconds (omitted for fire-and-forget events).
+ * @property {Error} [error] - The error thrown by the operation, if any.
+ * @property {string} [blockchain] - The blockchain the event relates to, if any.
+ * @property {Record<string, unknown>} [meta] - Additional event-specific metadata.
+ */
+/** @typedef {(event: TraceEvent) => void} TracerFn */
+/**
+ * @typedef {Object} WDKConfig
+ * @property {TracerFn} [tracer] - Optional observability hook. Called synchronously for every orchestrator operation with a structured event. Defaults to a no-op.
+ */
+/**
+ * Canonical event names emitted by the WDK orchestrator. Use this enum instead
+ * of magic strings when filtering or routing in a {@link TracerFn}.
+ */
+export const TraceEvents: Readonly<{
+    Created: "wdk.created";
+    WalletRegistered: "wdk.wallet.registered";
+    WalletRegisterFailed: "wdk.wallet.register_failed";
+    ProtocolRegistered: "wdk.protocol.registered";
+    MiddlewareRegistered: "wdk.middleware.registered";
+    MiddlewareExecuted: "wdk.middleware.executed";
+    MiddlewareFailed: "wdk.middleware.failed";
+    AccountResolved: "wdk.account.resolved";
+    AccountFailed: "wdk.account.failed";
+    FeeRatesResolved: "wdk.fee_rates.resolved";
+    FeeRatesFailed: "wdk.fee_rates.failed";
+    Disposed: "wdk.disposed";
+}>;
+export default class WDK {
     /**
      * Returns a random BIP-39 seed phrase.
      *
@@ -14,12 +50,13 @@ export default class WdkManager {
      */
     static isValidSeed(seed: string | Uint8Array): boolean;
     /**
-     * Creates a new wallet development kit manager.
+     * Creates a new wallet development kit instance.
      *
      * @param {string | Uint8Array} seed - The wallet's BIP-39 seed phrase.
+     * @param {WDKConfig} [config] - Optional WDK configuration.
      * @throws {Error} If the seed is not valid.
      */
-    constructor(seed: string | Uint8Array);
+    constructor(seed: string | Uint8Array, config?: WDKConfig);
     /** @private */
     private _seed;
     /** @private */
@@ -28,18 +65,20 @@ export default class WdkManager {
     private _protocols;
     /** @private */
     private _middlewares;
+    /** @private */
+    private _tracer;
     /**
-     * Registers a new wallet to the wdk manager.
+     * Registers a new wallet to WDK.
      *
      * @template {typeof WalletManager} W
      * @param {string} blockchain - The name of the blockchain the wallet must be bound to. Can be any string (e.g., "ethereum").
      * @param {W} WalletManager - The wallet manager class.
      * @param {ConstructorParameters<W>[1]} config - The configuration object.
-     * @returns {WdkManager} The wdk manager.
+     * @returns {WDK} The wdk instance.
      */
-    registerWallet<W extends typeof WalletManager>(blockchain: string, WalletManager: W, config: ConstructorParameters<W>[1]): WdkManager;
+    registerWallet<W extends typeof import("@tetherto/wdk-wallet").default>(blockchain: string, WalletManager: W, config: ConstructorParameters<W>[1]): WDK;
     /**
-     * Registers a new protocol to the wdk manager.
+     * Registers a new protocol to WDK.
      *
      * The label must be unique in the scope of the blockchain and the type of protocol (i.e., there can't be two protocols of the
      * same type bound to the same blockchain with the same label).
@@ -50,19 +89,19 @@ export default class WdkManager {
      * @param {string} label - The label.
      * @param {P} Protocol - The protocol class.
      * @param {ConstructorParameters<P>[1]} config - The protocol configuration.
-     * @returns {WdkManager} The wdk manager.
+     * @returns {WDK} The wdk instance.
      */
     registerProtocol<P extends typeof SwapProtocol | typeof BridgeProtocol | typeof LendingProtocol | typeof FiatProtocol>(blockchain: string, label: string, Protocol: P, config: ConstructorParameters<P>[1]): WDK;
     /**
-     * Registers a new middleware to the wdk manager.
+     * Registers a new middleware to WDK.
      *
      * It's possible to register multiple middlewares for the same blockchain, which will be called sequentially.
      *
      * @param {string} blockchain - The name of the blockchain the middleware must be bound to. Can be any string (e.g., "ethereum").
      * @param {MiddlewareFunction} middleware - A callback function that is called each time the user derives a new account.
-     * @returns {WdkManager} The wdk manager.
+     * @returns {WDK} The wdk instance.
      */
-    registerMiddleware(blockchain: string, middleware: MiddlewareFunction): WdkManager;
+    registerMiddleware(blockchain: string, middleware: MiddlewareFunction): WDK;
     /**
      * Returns the wallet account for a specific blockchain and index (see BIP-44).
      *
@@ -90,13 +129,15 @@ export default class WdkManager {
      */
     getFeeRates(blockchain: string): Promise<FeeRates>;
     /**
-    * Disposes and unregisters wallets, erasing any sensitive data from memory.
-    * If no blockchains are specified, all registered wallets are disposed.
-    * @param {string[]} [blockchains] - The blockchains to dispose. If omitted, all wallets are disposed.
-    */
+     * Disposes and unregisters wallets, erasing any sensitive data from memory.
+     * If no blockchains are specified, all registered wallets are disposed.
+     * @param {string[]} [blockchains] - The blockchains to dispose. If omitted, all wallets are disposed.
+     */
     dispose(blockchains?: string[]): void;
     /** @private */
     private _runMiddlewares;
+    /** @private */
+    private _trace;
     /** @private */
     private _registerProtocols;
 }
@@ -104,8 +145,40 @@ export type IWalletAccount = import("@tetherto/wdk-wallet").IWalletAccount;
 export type FeeRates = import("@tetherto/wdk-wallet").FeeRates;
 export type IWalletAccountWithProtocols = import("./wallet-account-with-protocols.js").IWalletAccountWithProtocols;
 export type MiddlewareFunction = <A extends IWalletAccount>(account: A) => Promise<void>;
-import WalletManager from "@tetherto/wdk-wallet";
-import { SwapProtocol } from "@tetherto/wdk-wallet/protocols";
-import { BridgeProtocol } from "@tetherto/wdk-wallet/protocols";
-import { LendingProtocol } from "@tetherto/wdk-wallet/protocols";
-import { FiatProtocol } from "@tetherto/wdk-wallet/protocols";
+export type TraceEvent = {
+    /**
+     * - The event name (e.g. "wdk.account.resolved").
+     */
+    name: string;
+    /**
+     * - Epoch milliseconds when the operation started.
+     */
+    startedAt: number;
+    /**
+     * - Elapsed time in milliseconds (omitted for fire-and-forget events).
+     */
+    durationMs?: number;
+    /**
+     * - The error thrown by the operation, if any.
+     */
+    error?: Error;
+    /**
+     * - The blockchain the event relates to, if any.
+     */
+    blockchain?: string;
+    /**
+     * - Additional event-specific metadata.
+     */
+    meta?: Record<string, unknown>;
+};
+export type TracerFn = (event: TraceEvent) => void;
+export type WDKConfig = {
+    /**
+     * - Optional observability hook. Called synchronously for every orchestrator operation with a structured event. Defaults to a no-op.
+     */
+    tracer?: TracerFn;
+};
+import { SwapProtocol } from '@tetherto/wdk-wallet/protocols';
+import { BridgeProtocol } from '@tetherto/wdk-wallet/protocols';
+import { LendingProtocol } from '@tetherto/wdk-wallet/protocols';
+import { FiatProtocol } from '@tetherto/wdk-wallet/protocols';


### PR DESCRIPTION
# Description

Adds an optional `tracer` hook to the WDK orchestrator. Every public operation (wallet/protocol/middleware registration, account derivation, fee-rate lookup, disposal) emits a structured event with timing and outcome metadata. Default is a no-op — zero overhead when unused, zero change to existing callers.

The full event vocabulary lives in a new exported `TraceEvents` enum so consumers filter/route by symbol rather than magic strings.

## Motivation and Context

The orchestrator is currently a black box from the consumer's perspective. There is no way to:

- Measure how long `getAccount` or `getFeeRates` actually take, per blockchain
- See which middleware in a chain threw, with timing
- Correlate a slow user-facing operation back to a specific orchestrator call
- Know that a protocol was just registered, or that a wallet was disposed
- Detect that account derivation is failing for one chain but not others

Every WDK consumer who wants this today has to fork the SDK, wrap every method at the call site, or instrument their wallet modules individually. The Tether wallet apps, third-party integrators, and any production deployment all hit the same wall.

A single `tracer` config field gives all of them a stable, structured hook with zero buy-in for callers who don't care.

### Example: integrating with an observability stack

```js
import WDK, { TraceEvents } from '@tetherto/wdk'

const wdk = new WDK(seed, {
  tracer (event) {
    datadog.timing(event.name, event.durationMs ?? 0, {
      blockchain: event.blockchain
    })

    if (event.error) {
      sentry.captureException(event.error, {
        tags: { event: event.name, blockchain: event.blockchain }
      })
    }
  }
})
```

This is the entire integration surface. The same shape adapts to pino, OpenTelemetry, custom log aggregators, or a `console.log` for local debugging.

### What this unlocks in operations

- **Latency regressions** — when `wdk.account.resolved` p99 jumps on one chain, the cause is a slow RPC or a slow middleware; the trace tells you which
- **Silent failures** — `wdk.middleware.failed` events surface compliance/auth middlewares that are timing out without anyone noticing
- **Customer support** — a per-session event log lets ops reconstruct what an app did, in order, with errors and timings
- **Cross-chain incidents** — `wdk.account.failed` rate spiking across all chains points at the orchestrator or the seed; spiking on one chain points at that chain's module or RPC

### Why an enum and not magic strings

Event names appear in 14 emit sites across the orchestrator. Without a single source of truth, drift was inevitable as the surface grew. `TraceEvents` is a frozen object exported from the package root so consumers can write `event.name === TraceEvents.AccountResolved` instead of string-matching.

## Design choices, explicitly

- **Synchronous tracer.** Keeps the orchestrator simple and predictable. If a consumer needs async (e.g. batch-shipping to a remote endpoint), they queue inside their tracer.
- **Tracer errors are swallowed.** A misbehaving tracer must never break wallet operations. Every emit is wrapped in `try { ... } catch {}`. The wallet's own errors still propagate exactly as before — the tracer sees them via `event.error` but does not consume them.
- **Non-function tracer values are ignored.** Defensive: if a consumer passes `null` / a string / `undefined`, the orchestrator silently uses the no-op default instead of throwing at construction.
- **Stable event shape.** Every event has `{ name, startedAt }`. Operations that complete add `durationMs`. Operations that fail add `error`. Operations bound to a chain add `blockchain`. Operation-specific data lives in a free-form `meta` field — never in top-level keys.
- **No event taxonomy beyond what the orchestrator emits.** No log levels, no filtering, no child contexts. Consumers' adapters handle that.

## Event vocabulary

| Event | When |
|---|---|
| `wdk.created` | A `new WDK(...)` succeeded |
| `wdk.wallet.registered` | `registerWallet` succeeded |
| `wdk.wallet.register_failed` | `registerWallet` threw |
| `wdk.protocol.registered` | `registerProtocol` succeeded; `meta` carries `{ kind, label }` |
| `wdk.middleware.registered` | `registerMiddleware` succeeded |
| `wdk.middleware.executed` | A middleware ran successfully during account derivation |
| `wdk.middleware.failed` | A middleware threw during account derivation |
| `wdk.account.resolved` | `getAccount` or `getAccountByPath` succeeded |
| `wdk.account.failed` | `getAccount` or `getAccountByPath` threw |
| `wdk.fee_rates.resolved` | `getFeeRates` succeeded |
| `wdk.fee_rates.failed` | `getFeeRates` threw |
| `wdk.disposed` | `dispose` completed; `meta.disposed` lists which blockchains were torn down |

## Backwards compatibility

Fully non-breaking.

- Constructor signature widened from `new WDK(seed)` to `new WDK(seed, config?)` — existing callers compile and run unchanged
- Default behavior is identical (no-op tracer)
- No public method signature changed
- No existing test required modification; 31 prior tests still pass exactly as before
- The `tracer` field is the sole new configuration surface

## Related Issue

No related issue. Surfaced as the highest-impact next step after the orchestrator hardening pass (#57).

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Verification

- 40/40 tests pass (31 existing + 9 new tracer tests covering: no-op default, every event type, error propagation, tracer-throw safety, non-function tracer values)
- `npm run lint` clean
- `npm run build:types` clean — regenerated `.d.ts` reflects the new `TraceEvents` export, `TracerFn`, `TraceEvent`, and `WDKConfig` types
- Manual integration test: registered a tracer, ran the existing example flows, confirmed event sequence matches the documented vocabulary