### PR TITLE
Release: v1.0.0-beta.11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@tetherto/wdk",
-  "version": "1.0.0-beta.10",
+  "version": "1.0.0-beta.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tetherto/wdk",
-      "version": "1.0.0-beta.10",
+      "version": "1.0.0-beta.11",
       "license": "Apache-2.0",
       "dependencies": {
-        "@tetherto/wdk-wallet": "^1.0.0-beta.9",
+        "@tetherto/wdk-wallet": "^1.0.0-beta.10",
         "bare-node-runtime": "^1.4.0",
         "zod": "^4.4.3"
       },
@@ -1283,12 +1283,12 @@
       }
     },
     "node_modules/@tetherto/wdk-wallet": {
-      "version": "1.0.0-beta.9",
-      "resolved": "https://registry.npmjs.org/@tetherto/wdk-wallet/-/wdk-wallet-1.0.0-beta.9.tgz",
-      "integrity": "sha512-sycU5+3fcgnJNR2vftGYykwrcqIzy9WKef6Yzwn7luS4S+MHDz+nfhhI0t9Qh3GMC+1m52LSMGBro3BPSHszNg==",
+      "version": "1.0.0-beta.10",
+      "resolved": "https://registry.npmjs.org/@tetherto/wdk-wallet/-/wdk-wallet-1.0.0-beta.10.tgz",
+      "integrity": "sha512-qCOxvNIltfwwMhOjWAgk2DN/0TZ+RjNOk10BXKQM2XMmq6KR8yJZV3Yc5FoJ+AFsCHZBhVJR6k6eF0/ZMI1pIA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "bare-node-runtime": "^1.1.4",
+        "bare-node-runtime": "^1.4.0",
         "bip39": "3.1.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tetherto/wdk",
-  "version": "1.0.0-beta.10",
+  "version": "1.0.0-beta.11",
   "description": "A flexible manager that can register and manage multiple wallet instances for different blockchains dynamically.",
   "keywords": [
     "wdk",
@@ -23,7 +23,7 @@
     "test:coverage": "cross-env NODE_OPTIONS=--experimental-vm-modules jest --coverage"
   },
   "dependencies": {
-    "@tetherto/wdk-wallet": "^1.0.0-beta.9",
+    "@tetherto/wdk-wallet": "^1.0.0-beta.10",
     "bare-node-runtime": "^1.4.0",
     "zod": "^4.4.3"
   },


### PR DESCRIPTION
- Bump version to 1.0.0-beta.11

### Changes since v1.0.0-beta.10
- feat: add Phase 1 local transaction policy engine (#55)
- Remove references to 'WdkManager' (#67)

### Dependency updates
- `@tetherto/wdk-wallet`: ^1.0.0-beta.9 → ^1.0.0-beta.10
- npm audit fix skipped — no vulnerabilities found

Made with [Cursor](https://cursor.com)