### PR TITLE
Release: v1.0.0-beta.15

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tetherto/wdk",
-  "version": "1.0.0-beta.14",
+  "version": "1.0.0-beta.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tetherto/wdk",
-      "version": "1.0.0-beta.14",
+      "version": "1.0.0-beta.15",
       "license": "Apache-2.0",
       "dependencies": {
         "@tetherto/wdk-wallet": "^1.0.0-beta.15",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tetherto/wdk",
-  "version": "1.0.0-beta.14",
+  "version": "1.0.0-beta.15",
   "description": "A flexible manager that can register and manage multiple wallet instances for different blockchains dynamically.",
   "keywords": [
     "wdk",


### PR DESCRIPTION
- Bump version to 1.0.0-beta.15

### Changes since v1.0.0-beta.14
- feat: add SDA protocol support (getSdaProtocol) (#73)
- fix(policy): don't expose signer or key material through enforced handles (#75)

### Dependency updates
- none (version-only release)
