### PR TITLE
Release: v1.0.0-beta.16

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tetherto/wdk",
-  "version": "1.0.0-beta.15",
+  "version": "1.0.0-beta.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tetherto/wdk",
-      "version": "1.0.0-beta.15",
+      "version": "1.0.0-beta.16",
       "license": "Apache-2.0",
       "dependencies": {
         "@tetherto/wdk-wallet": "^1.0.0-beta.15",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tetherto/wdk",
-  "version": "1.0.0-beta.15",
+  "version": "1.0.0-beta.16",
   "description": "A flexible manager that can register and manage multiple wallet instances for different blockchains dynamically.",
   "keywords": [
     "wdk",


### PR DESCRIPTION
- Bump version to 1.0.0-beta.16

### Changes since v1.0.0-beta.15
- feat(policy)!: drop context.params, standardize on args (#79)
- feat(policy): per-policy timeouts with engine-level ceiling (#78)
- fix(docs): gate the swidge example on a field config actually has (#78)

### Dependency updates
- None (version-only release)